### PR TITLE
Add platform.txt recipe for 'Export compiled binary' as a hex file

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -216,3 +216,45 @@ Generic_nRF51822.menu.softdevice.s130.softdeviceversion=2.0.0
 Generic_nRF51822.menu.softdevice.s130.upload.maximum_size=151552
 Generic_nRF51822.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 Generic_nRF51822.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_{build.chip}.ld
+
+Waveshare_BLE400.name=Waveshare BLE400
+
+Waveshare_BLE400.upload.tool=sandeepmistry:openocd
+Waveshare_BLE400.upload.target=nrf51
+Waveshare_BLE400.upload.maximum_size=262144
+
+Waveshare_BLE400.bootloader.tool=sandeepmistry:openocd
+
+Waveshare_BLE400.build.mcu=cortex-m0
+Waveshare_BLE400.build.f_cpu=16000000
+Waveshare_BLE400.build.board=WAVESHARE_BLE400
+Waveshare_BLE400.build.core=nRF5
+Waveshare_BLE400.build.variant=Waveshare_BLE400
+Waveshare_BLE400.build.variant_system_lib=
+Waveshare_BLE400.build.extra_flags=-DNRF51
+Waveshare_BLE400.build.float_flags=
+Waveshare_BLE400.build.ldscript=nrf51_{build.chip}.ld
+
+Waveshare_BLE400.menu.chip.xxaa=16 kB RAM, 256 kB flash (xxaa)
+Waveshare_BLE400.menu.chip.xxaa.build.chip=xxaa
+Waveshare_BLE400.menu.chip.xxac=32 kB RAM, 256 kB flash (xxac)
+Waveshare_BLE400.menu.chip.xxac.build.chip=xxac
+
+Waveshare_BLE400.menu.softdevice.none=None
+Waveshare_BLE400.menu.softdevice.none.softdevice=none
+
+Waveshare_BLE400.menu.softdevice.s110=S110
+Waveshare_BLE400.menu.softdevice.s110.softdevice=s110
+Waveshare_BLE400.menu.softdevice.s110.softdeviceversion=8.0.0
+Waveshare_BLE400.menu.softdevice.s110.upload.maximum_size=151552
+Waveshare_BLE400.menu.softdevice.s110.build.extra_flags=-DNRF51 -DS110 -DNRF51_S110
+Waveshare_BLE400.menu.softdevice.s110.build.ldscript=armgcc_s110_nrf51822_{build.chip}.ld
+
+Waveshare_BLE400.menu.softdevice.s130=S130
+Waveshare_BLE400.menu.softdevice.s130.softdevice=s130
+Waveshare_BLE400.menu.softdevice.s130.softdeviceversion=2.0.0
+Waveshare_BLE400.menu.softdevice.s130.upload.maximum_size=151552
+Waveshare_BLE400.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
+Waveshare_BLE400.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_{build.chip}.ld
+
+

--- a/platform.txt
+++ b/platform.txt
@@ -101,6 +101,10 @@ recipe.output.save_file_hex={build.project_name}.save.hex
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
 recipe.size.regex=\.text\s+([0-9]+).*
 
+## Export Compiled Binary
+recipe.output.tmp_file={build.project_name}.hex
+recipe.output.save_file={build.project_name}.{build.variant}.hex
+
 #
 # OpenOCD sketch upload
 #

--- a/variants/Waveshare_BLE400/pins_arduino.h
+++ b/variants/Waveshare_BLE400/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/Waveshare_BLE400/variant.cpp
+++ b/variants/Waveshare_BLE400/variant.cpp
@@ -1,0 +1,55 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
+  24,
+  25,
+  26,
+  27,
+  28,
+  29,
+  30,
+  31
+};

--- a/variants/Waveshare_BLE400/variant.h
+++ b/variants/Waveshare_BLE400/variant.h
@@ -1,0 +1,111 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_GENERIC_
+#define _VARIANT_GENERIC_
+
+/** Master clock frequency */
+#ifdef NRF52
+#define VARIANT_MCK       (64000000ul)
+#else
+#define VARIANT_MCK       (16000000ul)
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (31u)
+#define NUM_DIGITAL_PINS     (31u)
+#define NUM_ANALOG_INPUTS    (6u)
+#define NUM_ANALOG_OUTPUTS   (0u)
+
+// LEDs
+#define PIN_LED1              (18)
+#define PIN_LED2              (19)
+#define PIN_LED3              (20)
+#define PIN_LED4              (21)
+#define PIN_LED5              (22)
+#define LED_BUILTIN          PIN_LED1
+
+// Buttons
+#define PIN_BUTTON1             (16)
+#define PIN_BUTTON2             (17)
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (2)
+#define PIN_A1               (3)
+#define PIN_A2               (4)
+#define PIN_A3               (5)
+#define PIN_A4               (6)
+#define PIN_A5               (7)
+
+static const uint8_t A0  = PIN_A0 ;
+static const uint8_t A1  = PIN_A1 ;
+static const uint8_t A2  = PIN_A2 ;
+static const uint8_t A3  = PIN_A3 ;
+static const uint8_t A4  = PIN_A4 ;
+static const uint8_t A5  = PIN_A5 ;
+#ifdef NRF52
+#define ADC_RESOLUTION    14
+#else
+#define ADC_RESOLUTION    10
+#endif
+
+/*
+ * Serial interfaces
+ */
+// Serial
+#define PIN_SERIAL_RX       (11)
+#define PIN_SERIAL_TX       (9)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+
+#define PIN_SPI_MISO         (23)
+#define PIN_SPI_MOSI         (24)
+#define PIN_SPI_SCK          (25)
+
+static const uint8_t SS   = 30 ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA         (0u)
+#define PIN_WIRE_SCL         (1u)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Sandeep, I added the 2 lines needed for the IDE to support the "Export compiled Binary" menu feature, (on the Sketch menu).

I've set this to use the hex version of file rather than the binary (bin) version, as the Hex file has the start offset in it, which will be needed if anyone wants to upload using JFlash etc