### PR TITLE
Support for some NRF boards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
   - buildExampleSketch sandeepmistry:nRF5:BBCmicrobit 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:Generic_nRF51822:chip=xxac 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:OSHChip 01.Basics Blink
+  - buildExampleSketch sandeepmistry:nRF5:STCT_nRF52_minidev 01.Basics Blink

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,5 @@ script:
   - buildExampleSketch sandeepmistry:nRF5:Generic_nRF52832 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:OSHChip 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:STCT_nRF52_minidev 01.Basics Blink
+  - buildExampleSketch sandeepmistry:nRF5:PCA1000X:board_variant=pca10000 01.Basics Blink
+  - buildExampleSketch sandeepmistry:nRF5:PCA1000X:board_variant=nrf6310 01.Basics Blink

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ script:
   - buildExampleSketch sandeepmistry:nRF5:RedBearLab_nRF51822:version=1_0 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:BBCmicrobit 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:Generic_nRF51822:chip=xxac 01.Basics Blink
+  - buildExampleSketch sandeepmistry:nRF5:Generic_nRF52832 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:OSHChip 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:STCT_nRF52_minidev 01.Basics Blink

--- a/README.md
+++ b/README.md
@@ -8,13 +8,22 @@ Does not require a custom bootloader on the device.
 
 ## Supported boards
 
- * [nRF52 DK](https://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF52-DK)
+### nRF52
+ * [Plain nRF52 MCU](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52832)
+ * [Nordic Semiconductor nRF52 DK](https://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF52-DK)
    * For boards prior to ```2016.9``` (see sticker), the lastest JLink bootloader is required to upload sketches. To upgrade, press the boot/reset button while powering on the board and copy over the latest [bootloader](https://www.nordicsemi.com/eng/nordic/Products/nRF52-DK/nRF5x-OB-JLink-IF/52275).
+ * [Shenzhen Taida Century Technology nRF52 low cost development board](https://www.aliexpress.com/item/NRF52832-high-cost-development-board-gold-core-board/32725601299.html)
+
+### nRF51
+ * [Plain nRF51 MCU](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822)
+ * [BBC micro:bit](https://www.microbit.co.uk/)
  * [Bluz DK](http://bluz.io)
+ * Nordic Semiconductor  [nRF51822 Development Kit](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822-Development-Kit) + [nRF51422 Development Kit](https://www.nordicsemi.com/eng/Products/ANT/nRF51422-Development-Kit)
+  * PCA10000
+  * PCA10001, PCA10002, PCA10003, PCA10004 via nRF6310(nRFgo)
+ * [OSHChip](http://www.oshchip.org/)
  * [RedBearLab BLE Nano](http://redbearlab.com/blenano/)
  * [RedBearLab nRF51822](http://redbearlab.com/redbearlab-nrf51822/)
- * [BBC micro:bit](https://www.microbit.co.uk/)
- * [OSHChip](http://www.oshchip.org/)
 
 ## Installing
 

--- a/boards.txt
+++ b/boards.txt
@@ -261,7 +261,7 @@ BBCmicrobit.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 BBCmicrobit.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxaa.ld
 
 
-Generic_nRF51822.name=Generic nRF51822
+Generic_nRF51822.name=Generic nRF51
 
 Generic_nRF51822.upload.tool=sandeepmistry:openocd
 Generic_nRF51822.upload.target=nrf51
@@ -307,6 +307,42 @@ Generic_nRF51822.menu.lfclk.lfrc=RC Oscillator
 Generic_nRF51822.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
 Generic_nRF51822.menu.lfclk.lfsynt=Synthesized
 Generic_nRF51822.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT
+
+
+Generic_nRF52832.name=Generic nRF52
+
+Generic_nRF52832.upload.tool=sandeepmistry:openocd
+Generic_nRF52832.upload.target=nrf52
+Generic_nRF52832.upload.maximum_size=524288
+
+Generic_nRF52832.bootloader.tool=sandeepmistry:openocd
+
+Generic_nRF52832.build.mcu=cortex-m4
+Generic_nRF52832.build.f_cpu=16000000
+Generic_nRF52832.build.board=GENERIC
+Generic_nRF52832.build.core=nRF5
+Generic_nRF52832.build.variant=Generic
+Generic_nRF52832.build.variant_system_lib=
+Generic_nRF52832.build.extra_flags=-DNRF52
+Generic_nRF52832.build.float_flags=-mfloat-abi=hard -mfpu=fpv4-sp-d16
+Generic_nRF52832.build.ldscript=nrf52_xxaa.ld
+
+Generic_nRF52832.menu.softdevice.none=None
+Generic_nRF52832.menu.softdevice.none.softdevice=none
+
+Generic_nRF52832.menu.softdevice.s132=S132
+Generic_nRF52832.menu.softdevice.s132.softdevice=s132
+Generic_nRF52832.menu.softdevice.s132.softdeviceversion=2.0.1
+Generic_nRF52832.menu.softdevice.s132.upload.maximum_size=409600
+Generic_nRF52832.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+Generic_nRF52832.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
+
+Generic_nRF52832.menu.lfclk.lfxo=Crystal Oscillator
+Generic_nRF52832.menu.lfclk.lfxo.build.lfclk_flags=-DUSE_LFXO
+Generic_nRF52832.menu.lfclk.lfrc=RC Oscillator
+Generic_nRF52832.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
+Generic_nRF52832.menu.lfclk.lfsynt=Synthesized
+Generic_nRF52832.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT
 
 
 Waveshare_BLE400.name=Waveshare BLE400

--- a/boards.txt
+++ b/boards.txt
@@ -19,6 +19,7 @@ menu.chip=Chip
 menu.softdevice=Softdevice
 menu.version=Version
 menu.lfclk=Low Frequency Clock
+menu.board_variant=Board Variant
 
 nRF52DK.name=nRF52 DK
 
@@ -422,3 +423,57 @@ OSHChip.menu.softdevice.s130.softdeviceversion=2.0.1
 OSHChip.menu.softdevice.s130.upload.maximum_size=151552
 OSHChip.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 OSHChip.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxac.ld
+
+PCA1000X.name=nRF51X22 Development Kit(PCA1000X)
+
+PCA1000X.upload.tool=sandeepmistry:openocd
+PCA1000X.upload.target=nrf51
+PCA1000X.upload.maximum_size=262144
+
+PCA1000X.bootloader.tool=sandeepmistry:openocd
+
+PCA1000X.build.mcu=cortex-m0
+PCA1000X.build.f_cpu=16000000
+PCA1000X.build.board=PCA1000X
+PCA1000X.build.core=nRF5
+PCA1000X.build.variant=PCA1000X
+PCA1000X.build.variant_system_lib=
+PCA1000X.build.extra_flags=-DNRF51 -D{board.variant}
+PCA1000X.build.float_flags=
+PCA1000X.build.ldscript=nrf51_xxaa.ld
+
+PCA1000X.upload.tool=sandeepmistry:openocd
+PCA1000X.upload.protocol=
+PCA1000X.upload.interface=jlink
+PCA1000X.upload.target=nrf51
+PCA1000X.upload.maximum_size=262144
+PCA1000X.upload.setup_command=transport select swd; set WORKAREASIZE 0;
+
+PCA1000X.menu.board_variant.pca10000=PCA10000
+PCA1000X.menu.board_variant.pca10000.board.variant=PCA10000
+PCA1000X.menu.board_variant.nrf6310=PCA1000X (via nRF6310)
+PCA1000X.menu.board_variant.nrf6310.board.variant=NRF6310
+
+PCA1000X.menu.softdevice.none=None
+PCA1000X.menu.softdevice.none.softdevice=none
+
+PCA1000X.menu.softdevice.s110=S110
+PCA1000X.menu.softdevice.s110.softdevice=s110
+PCA1000X.menu.softdevice.s110.softdeviceversion=8.0.0
+PCA1000X.menu.softdevice.s110.upload.maximum_size=151552
+PCA1000X.menu.softdevice.s110.build.extra_flags=-DNRF51 -DS110 -DNRF51_S110
+PCA1000X.menu.softdevice.s110.build.ldscript=armgcc_s110_nrf51822_xxaa.ld
+
+PCA1000X.menu.softdevice.s130=S130
+PCA1000X.menu.softdevice.s130.softdevice=s130
+PCA1000X.menu.softdevice.s130.softdeviceversion=2.0.1
+PCA1000X.menu.softdevice.s130.upload.maximum_size=151552
+PCA1000X.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
+PCA1000X.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxaa.ld
+
+PCA1000X.menu.lfclk.lfxo=Crystal Oscillator
+PCA1000X.menu.lfclk.lfxo.build.lfclk_flags=-DUSE_LFXO
+PCA1000X.menu.lfclk.lfrc=RC Oscillator
+PCA1000X.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
+PCA1000X.menu.lfclk.lfsynt=Synthesized
+PCA1000X.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT

--- a/boards.txt
+++ b/boards.txt
@@ -64,6 +64,43 @@ nRF52DK.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
 nRF52DK.menu.lfclk.lfsynt=Synthesized
 nRF52DK.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT
 
+
+STCT_nRF52_minidev.name=Taida Century nRF52 mini board
+
+STCT_nRF52_minidev.upload.tool=sandeepmistry:openocd
+STCT_nRF52_minidev.upload.target=nrf52
+STCT_nRF52_minidev.upload.maximum_size=524288
+
+STCT_nRF52_minidev.bootloader.tool=sandeepmistry:openocd
+
+STCT_nRF52_minidev.build.mcu=cortex-m4
+STCT_nRF52_minidev.build.f_cpu=16000000
+STCT_nRF52_minidev.build.board=STCT_NRF52_minidev
+STCT_nRF52_minidev.build.core=nRF5
+STCT_nRF52_minidev.build.variant=Taida_Century_nRF52_minidev
+STCT_nRF52_minidev.build.variant_system_lib=
+STCT_nRF52_minidev.build.extra_flags=-DNRF52
+STCT_nRF52_minidev.build.float_flags=-mfloat-abi=hard -mfpu=fpv4-sp-d16
+STCT_nRF52_minidev.build.ldscript=nrf52_xxaa.ld
+
+STCT_nRF52_minidev.menu.softdevice.none=None
+STCT_nRF52_minidev.menu.softdevice.none.softdevice=none
+
+STCT_nRF52_minidev.menu.softdevice.s132=S132
+STCT_nRF52_minidev.menu.softdevice.s132.softdevice=s132
+STCT_nRF52_minidev.menu.softdevice.s132.softdeviceversion=2.0.1
+STCT_nRF52_minidev.menu.softdevice.s132.upload.maximum_size=409600
+STCT_nRF52_minidev.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+STCT_nRF52_minidev.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
+
+STCT_nRF52_minidev.menu.lfclk.lfxo=Crystal Oscillator
+STCT_nRF52_minidev.menu.lfclk.lfxo.build.lfclk_flags=-DUSE_LFXO
+STCT_nRF52_minidev.menu.lfclk.lfrc=RC Oscillator
+STCT_nRF52_minidev.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
+STCT_nRF52_minidev.menu.lfclk.lfsynt=Synthesized
+STCT_nRF52_minidev.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT
+
+
 BluzDK.name=Bluz DK
 
 BluzDK.upload.tool=sandeepmistry:openocd
@@ -182,7 +219,6 @@ RedBearLab_nRF51822.menu.softdevice.s130.softdeviceversion=2.0.1
 RedBearLab_nRF51822.menu.softdevice.s130.upload.maximum_size=151552
 RedBearLab_nRF51822.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 RedBearLab_nRF51822.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_{build.chip}.ld
-
 
 BBCmicrobit.name=BBC micro:bit
 

--- a/variants/PCA1000X/pins_arduino.h
+++ b/variants/PCA1000X/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/PCA1000X/variant.cpp
+++ b/variants/PCA1000X/variant.cpp
@@ -1,0 +1,68 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2016 Frank Holtz. All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+#ifdef PCA10000
+const uint32_t g_ADigitalPinMap[] = {
+  8,  // RTS
+  9,  // TxD
+  10, // CTS
+  11, // RxD
+  21, // LED Red
+  22, // LED Green
+  23, // LED Blue
+};
+#else
+const uint32_t g_ADigitalPinMap[] = {
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
+  24,
+  25,
+  26,
+  27,
+  28,
+  29,
+  30,
+  31
+};
+#endif

--- a/variants/PCA1000X/variant.h
+++ b/variants/PCA1000X/variant.h
@@ -1,0 +1,141 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2016 Frank Holtz. All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_PCA1000X_
+#define _VARIANT_PCA1000X_
+
+/** Master clock frequency */
+#define VARIANT_MCK       (16000000ul)
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#ifndef PCA10000
+  /* PCA1000[1,2,3,4] on nRF6310
+   * ****************************/
+  #define PINS_COUNT           (32u)
+  #define NUM_DIGITAL_PINS     (32u)
+  #define NUM_ANALOG_INPUTS    (6u)
+  #define NUM_ANALOG_OUTPUTS   (0u)
+
+  // LEDs
+  #define PIN_LED1                (8)
+  #define PIN_LED2                (9)
+  #define PIN_LED3                (10)
+  #define PIN_LED4                (11)
+  #define PIN_LED5                (12)
+  #define PIN_LED6                (13)
+  #define PIN_LED7                (14)
+  #define PIN_LED8                (15)
+  #define LED_BUILTIN             PIN_LED1
+
+  // Buttons
+  #define PIN_BUTTON1             (0)
+  #define PIN_BUTTON2             (1)
+  #define PIN_BUTTON3             (2)
+  #define PIN_BUTTON4             (3)
+  #define PIN_BUTTON5             (4)
+  #define PIN_BUTTON6             (5)
+  #define PIN_BUTTON7             (6)
+  #define PIN_BUTTON8             (7)
+
+  /*
+   * Analog pins
+   */
+  #define PIN_A0               (26)
+  #define PIN_A1               (27)
+  #define PIN_A2               (28)
+  #define PIN_A3               (29)
+  #define PIN_A4               (30)
+  #define PIN_A5               (31)
+
+  static const uint8_t A0  = PIN_A0 ;
+  static const uint8_t A1  = PIN_A1 ;
+  static const uint8_t A2  = PIN_A2 ;
+  static const uint8_t A3  = PIN_A3 ;
+  static const uint8_t A4  = PIN_A4 ;
+  static const uint8_t A5  = PIN_A5 ;
+
+  #define ADC_RESOLUTION    10
+
+  /*
+   * Serial interfaces
+   */
+  #define PIN_SERIAL_RX       (16)
+  #define PIN_SERIAL_TX       (17)
+
+  /*
+   * SPI Interfaces
+   */
+  #define SPI_INTERFACES_COUNT 1
+
+  #define PIN_SPI_MISO         (18)
+  #define PIN_SPI_MOSI         (19)
+  #define PIN_SPI_SCK          (20)
+
+  static const uint8_t SS   = 25 ;
+  static const uint8_t MOSI = PIN_SPI_MOSI ;
+  static const uint8_t MISO = PIN_SPI_MISO ;
+  static const uint8_t SCK  = PIN_SPI_SCK ;
+
+  /*
+   * Wire Interfaces
+   */
+  #define WIRE_INTERFACES_COUNT 1
+
+  #define PIN_WIRE_SDA         (25u)
+  #define PIN_WIRE_SCL         (24u)
+
+#else
+  /* PCA10000
+   * *********/
+
+  #define PINS_COUNT           (7u)
+  #define NUM_DIGITAL_PINS     (7u)
+  #define NUM_ANALOG_INPUTS    (0u)
+  #define NUM_ANALOG_OUTPUTS   (0u)
+
+  // LEDs
+  #define PIN_LED1                (4)
+  #define PIN_LED2                (5)
+  #define PIN_LED3                (6)
+  #define LED_BUILTIN             PIN_LED1
+
+  /*
+   * Serial interfaces
+   */
+  #define PIN_SERIAL_RX       (3)
+  #define PIN_SERIAL_CTS      (2)
+  #define PIN_SERIAL_TX       (1)
+  #define PIN_SERIAL_RTS      (0)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/variants/Taida_Century_nRF52_minidev/pins_arduino.h
+++ b/variants/Taida_Century_nRF52_minidev/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/Taida_Century_nRF52_minidev/variant.cpp
+++ b/variants/Taida_Century_nRF52_minidev/variant.cpp
@@ -1,0 +1,62 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2016 Frank Holtz. All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  // D0 - D7
+  25, // D0, near Radio! -> Low drive, low frequency I/O only.
+  26, // D1, near Radio! -> Low drive, low frequency I/O only.
+  27, // D2, near Radio! -> Low drive, low frequency I/O only.
+  28, // D3, near Radio! -> Low drive, low frequency I/O only.
+  29, // D4, NOT CONNECTED, near Radio! -> Low drive, low frequency I/O only.
+  30, // D5, LED1, near Radio! -> Low drive, low frequency I/O only.
+  31, // D6, LED2, near Radio! -> Low drive, low frequency I/O only.
+  2,  // D7, PIN_WIRE_SDA
+
+  // D8 - D13
+  3,  // D8, PIN_WIRE_SCL
+  4,  // D9, BUTTON1, NFC-Antenna 1
+  5,  // D10
+  0,  // D11, NOT CONNECTED
+  1,  // D12, NOT CONNECTED
+  6,  // D13
+
+  // D14 - D30
+  7,  // D14
+  8,  // D15
+  9,  // D16, NOT CONNECTED
+  10, // D17, NFC-Antenna 2, NOT CONNECTED
+  11, // D18, RXD
+  12, // D19, TXD
+  13, // D20, SS
+  14, // D21, MISO
+  15, // D22, MOSI
+  16, // D23, SCK
+  17, // D24, A0
+  18, // D25, A1
+  19, // D26, A2
+  20, // D27, A3
+  22, // D28, A4, near Radio! -> Low drive, low frequency I/O only.
+  23, // D29, A5, near Radio! -> Low drive, low frequency I/O only.
+  24, // D30,
+  
+  21, // RESET
+};

--- a/variants/Taida_Century_nRF52_minidev/variant.h
+++ b/variants/Taida_Century_nRF52_minidev/variant.h
@@ -1,0 +1,112 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2016 Frank Holtz. All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_NRF52_MINIDEV_
+#define _VARIANT_NRF52_MINIDEV_
+
+/** Master clock frequency */
+#define VARIANT_MCK       (64000000ul)
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (32u)
+#define NUM_DIGITAL_PINS     (20u)
+#define NUM_ANALOG_INPUTS    (6u)
+#define NUM_ANALOG_OUTPUTS   (0u)
+
+// LEDs
+#define PIN_LED1                (5)
+#define PIN_LED2                (6)
+#define LED_BUILTIN             PIN_LED1
+
+// Buttons
+// KEY
+#define PIN_BUTTON1             (9)
+// Reset -> read nordic documentation for disabling reset function
+#define PIN_BUTTON2             (31)
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (25)
+#define PIN_A1               (26)
+#define PIN_A2               (27)
+#define PIN_A3               (28)
+#define PIN_A4               (29)
+#define PIN_A5               (30)
+
+static const uint8_t A0  = PIN_A0 ;
+static const uint8_t A1  = PIN_A1 ;
+static const uint8_t A2  = PIN_A2 ;
+static const uint8_t A3  = PIN_A3 ;
+static const uint8_t A4  = PIN_A4 ;
+static const uint8_t A5  = PIN_A5 ;
+#define ADC_RESOLUTION    14
+
+// Other pins
+#define PIN_AREF           (24)
+static const uint8_t AREF = PIN_AREF;
+
+/*
+ * Serial interfaces
+ */
+// Serial
+#define PIN_SERIAL_RX       (18)
+#define PIN_SERIAL_TX       (19)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+
+#define PIN_SPI_MISO         (21)
+#define PIN_SPI_MOSI         (22)
+#define PIN_SPI_SCK          (23)
+
+static const uint8_t SS   = 20 ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA         (2u)
+#define PIN_WIRE_SCL         (3u)
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
nRF51: PCA1000X come from Nordic nRF51 DK
Generic nRF52: Same like "Generic nRF51"
nRF52_minidev: This board is available via aliexpress when searching for nrf52832

I have added hardware flow control to UART driver to support PCA10000.