### PR TITLE
Add UART hardware flow control

### DIFF
--- a/cores/nRF5/Uart.cpp
+++ b/cores/nRF5/Uart.cpp
@@ -27,18 +27,18 @@ Uart::Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pi
   IRQn = _IRQn;
   uc_pinRX = g_ADigitalPinMap[_pinRX];
   uc_pinTX = g_ADigitalPinMap[_pinTX];
-  uc_do_hwflow = 0;
+  uc_hwFlow = 0;
 }
 
-Uart::Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pinTX, uint8_t _pinCTS, uint8_t _pinRTS )
+Uart::Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pinTX, uint8_t _pinCTS, uint8_t _pinRTS)
 {
   nrfUart = _nrfUart;
   IRQn = _IRQn;
   uc_pinRX = g_ADigitalPinMap[_pinRX];
   uc_pinTX = g_ADigitalPinMap[_pinTX];
   uc_pinCTS = g_ADigitalPinMap[_pinCTS];
-  uc_pinRTS = g_ADigitalPinMap[_pinRTS];  
-  uc_do_hwflow = 1;
+  uc_pinRTS = g_ADigitalPinMap[_pinRTS];
+  uc_hwFlow = 1;
 }
 
 void Uart::begin(unsigned long baudrate)
@@ -50,8 +50,8 @@ void Uart::begin(unsigned long baudrate, uint16_t /*config*/)
 {
   nrfUart->PSELTXD = uc_pinTX;
   nrfUart->PSELRXD = uc_pinRX;
-  
-  if (uc_do_hwflow == 1) {
+
+  if (uc_hwFlow == 1) {
     nrfUart->PSELCTS = uc_pinCTS;
     nrfUart->PSELRTS = uc_pinRTS;
     nrfUart->CONFIG = (UART_CONFIG_PARITY_Excluded << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Enabled;

--- a/cores/nRF5/Uart.cpp
+++ b/cores/nRF5/Uart.cpp
@@ -27,6 +27,18 @@ Uart::Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pi
   IRQn = _IRQn;
   uc_pinRX = g_ADigitalPinMap[_pinRX];
   uc_pinTX = g_ADigitalPinMap[_pinTX];
+  uc_do_hwflow = 0;
+}
+
+Uart::Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pinTX, uint8_t _pinCTS, uint8_t _pinRTS )
+{
+  nrfUart = _nrfUart;
+  IRQn = _IRQn;
+  uc_pinRX = g_ADigitalPinMap[_pinRX];
+  uc_pinTX = g_ADigitalPinMap[_pinTX];
+  uc_pinCTS = g_ADigitalPinMap[_pinCTS];
+  uc_pinRTS = g_ADigitalPinMap[_pinRTS];  
+  uc_do_hwflow = 1;
 }
 
 void Uart::begin(unsigned long baudrate)
@@ -38,8 +50,15 @@ void Uart::begin(unsigned long baudrate, uint16_t /*config*/)
 {
   nrfUart->PSELTXD = uc_pinTX;
   nrfUart->PSELRXD = uc_pinRX;
+  
+  if (uc_do_hwflow == 1) {
+    nrfUart->PSELCTS = uc_pinCTS;
+    nrfUart->PSELRTS = uc_pinRTS;
+    nrfUart->CONFIG = (UART_CONFIG_PARITY_Excluded << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Enabled;
+  } else {
+    nrfUart->CONFIG = (UART_CONFIG_PARITY_Excluded << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Disabled;
+  }
 
-  nrfUart->CONFIG = (UART_CONFIG_PARITY_Excluded << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Disabled;
 
   uint32_t nrfBaudRate;
 
@@ -144,6 +163,9 @@ void Uart::end()
   nrfUart->PSELTXD = 0xFFFFFFFF;
   nrfUart->PSELRXD = 0xFFFFFFFF;
 
+  nrfUart->PSELRTS = 0xFFFFFFFF;
+  nrfUart->PSELCTS = 0xFFFFFFFF;
+
   rxBuffer.clear();
 }
 
@@ -188,8 +210,18 @@ size_t Uart::write(const uint8_t data)
 }
 
 #if defined(NRF52)
-Uart Serial( NRF_UART0, UARTE0_UART0_IRQn, PIN_SERIAL_RX, PIN_SERIAL_TX );
+  #define NRF_UART0_IRQn UARTE0_UART0_IRQn
+#elif defined(NRF51)
+  #define NRF_UART0_IRQn UART0_IRQn
+#endif
 
+#if defined(PIN_SERIAL_CTS) && defined(PIN_SERIAL_RTS)
+  Uart Serial( NRF_UART0, NRF_UART0_IRQn, PIN_SERIAL_RX, PIN_SERIAL_TX, PIN_SERIAL_CTS, PIN_SERIAL_RTS );
+#else
+  Uart Serial( NRF_UART0, NRF_UART0_IRQn, PIN_SERIAL_RX, PIN_SERIAL_TX );
+#endif
+
+#if defined(NRF52)
 extern "C"
 {
   void UARTE0_UART0_IRQHandler()
@@ -198,8 +230,6 @@ extern "C"
   }
 }
 #elif defined(NRF51)
-Uart Serial( NRF_UART0, UART0_IRQn, PIN_SERIAL_RX, PIN_SERIAL_TX );
-
 extern "C"
 {
   void UART0_IRQHandler()

--- a/cores/nRF5/Uart.h
+++ b/cores/nRF5/Uart.h
@@ -30,6 +30,7 @@ class Uart : public HardwareSerial
 {
   public:
     Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pinTX);
+    Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pinTX, uint8_t _pinCTS, uint8_t _pinRTS );
     void begin(unsigned long baudRate);
     void begin(unsigned long baudrate, uint16_t config);
     void end();
@@ -52,6 +53,10 @@ class Uart : public HardwareSerial
 
     uint8_t uc_pinRX;
     uint8_t uc_pinTX;
+    uint8_t uc_pinCTS;
+    uint8_t uc_pinRTS;
+    uint8_t uc_do_hwflow;
+
 };
 
 #ifdef __cplusplus

--- a/cores/nRF5/Uart.h
+++ b/cores/nRF5/Uart.h
@@ -55,8 +55,7 @@ class Uart : public HardwareSerial
     uint8_t uc_pinTX;
     uint8_t uc_pinCTS;
     uint8_t uc_pinRTS;
-    uint8_t uc_do_hwflow;
-
+    uint8_t uc_hwFlow;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Adds hardware flow control to UART/UARTE. To enable RTS/CTS define PIN_SERIAL_CTS and PIN_SERIAL_RTS
