### PR TITLE
correction nRF5FlashSoftDevice

### DIFF
--- a/extras/ide-tools/build.sh
+++ b/extras/ide-tools/build.sh
@@ -1,7 +1,19 @@
 #!/bin/sh -x
 
-IDE_LIB_PATH=/Applications/Arduino.app/Contents/Java
+# search for arduino IDE: OSX, Linux:opt, Debian, EPEL
+for IDE_LIB_PATH in /Applications/Arduino.app/Contents/Java /opt/arduino/lib /usr/share/arduino/lib/ /usr/share/arduino; do
+	if [ -e "${IDE_LIB_PATH}/pde.jar" ]; then
+		if [ -f "${IDE_LIB_PATH}/arduino-core.jar" ]; then
+			ARDUINO_CORE="arduino-core.jar"
+		else
+			ARDUINO_CORE="core.jar"
+		fi
+		break
+	fi
+done
+
+PATH="$JAVA_HOME:$PATH"
 
 rm -rf bin
 mkdir -p bin
-javac -target 1.8 -cp "$IDE_LIB_PATH/pde.jar:$IDE_LIB_PATH/arduino-core.jar" -d bin *.java && jar cvf nRF5FlashSoftDevice.jar -C bin .
+javac -target 1.8 -cp "${IDE_LIB_PATH}/pde.jar:${IDE_LIB_PATH}/${ARDUINO_CORE}" -d bin *.java && jar cvf nRF5FlashSoftDevice.jar -C bin .


### PR DESCRIPTION
I have modified the nRF5FlashSoftDevice.java file, because your username is hardcoded in it. This prohibits using a unmodified file in my own package of arduino-nRF5.

In my opinion at the moment there is no need to check the name, because the tool fails if a programmer without a softdevice.txt file is selected.

I have added a check to test if the chosen programmer have to capability to upload a boot loader. 

My plan is to write a boot loader with OTA flash functionality which dosn't depend on accepting the NRF SDK license. Maybe somebody implementing a BLE support for http://mynewt.apache.org/pages/ble/

In my opinion this tool needs to replaced with a "SDK and SoftDevice" downloader. This allows to remove file in https://github.com/sandeepmistry/arduino-nRF5/tree/master/cores/nRF5/SDK with non free copyright. The SoftDevice can flashed via "burn bootloader" option from "Tools" menu.