### PR TITLE
Config gpio as pinreset

### DIFF
--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -67,7 +67,7 @@ extern void analogWrite( uint32_t ulPin, uint32_t ulValue ) ;
 #ifdef NEW_PWM
 extern void initPwm   (uint8_t pwmId, float fFreq);
 extern void deinitPwm (uint8_t pwmId);
-extern void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId);
+extern void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId, bool invert);
 #endif
 /*
  * \brief Reads the value from the specified analog pin.

--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -65,7 +65,7 @@ extern void analogReference( eAnalogReference ulMode ) ;
 extern void analogWrite( uint32_t ulPin, uint32_t ulValue ) ;
 #define NEW_PWM
 #ifdef NEW_PWM
-extern void initPwm   (uint8_t pwmId, uint32_t ulFreq);
+extern void initPwm   (uint8_t pwmId, float fFreq);
 extern void deinitPwm (uint8_t pwmId);
 extern void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId);
 #endif

--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -63,7 +63,12 @@ extern void analogReference( eAnalogReference ulMode ) ;
  * \param ulValue
  */
 extern void analogWrite( uint32_t ulPin, uint32_t ulValue ) ;
-
+#define NEW_PWM
+#ifdef NEW_PWM
+extern void initPwm   (uint8_t pwmId, uint32_t ulFreq);
+extern void deinitPwm (uint8_t pwmId);
+extern void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId);
+#endif
 /*
  * \brief Reads the value from the specified analog pin.
  *

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -247,7 +247,7 @@ void analogWrite( uint32_t ulPin, uint32_t ulValue )
     if (pwmChannelPins[i] == 0xFFFFFFFF || pwmChannelPins[i] == ulPin) {
       pwmChannelPins[i] = ulPin;
       pwmChannelSequence[i] = ulValue;
-	  pwmChannelSequence[i]|= 1<<15; //JH
+      pwmChannelSequence[i]|= 1<<15; //set invert bit
 
       NRF_PWM_Type* pwm = pwms[i];
 
@@ -260,8 +260,8 @@ void analogWrite( uint32_t ulPin, uint32_t ulValue )
       pwm->MODE = PWM_MODE_UPDOWN_Up;
       pwm->COUNTERTOP = (1 << writeResolution) - 1;
       pwm->LOOP = 0;
-      pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Common << PWM_DECODER_LOAD_Pos) 		//JH initPWM?
-	               | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);	//JH initPWM?
+      pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Common << PWM_DECODER_LOAD_Pos)
+                   | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
       pwm->SEQ[0].PTR = (uint32_t)&pwmChannelSequence[i];
       pwm->SEQ[0].CNT = 1;
       pwm->SEQ[0].REFRESH  = 1;
@@ -281,20 +281,19 @@ extern  void a_printf(const char *fmt, ... );
 
 void analogWrite(uint32_t ulPin, uint32_t ulValue )
 {
-	if (pwmFrequency[0]==0.) initPwm(0, 500.);
-	analogWritePwm(ulPin, ulValue, 0);
+  if (pwmFrequency[0]==0.) initPwm(0, 500.);
+  analogWritePwm(ulPin, ulValue, 0);
 }
 
 void deinitPwm(uint8_t pwmId)
 {
-	if (pwmId>=PWM_COUNT) {
-		return;
-	}
-	
-	//nrf_pwm_disable(pwms[pwmId]);
-	pwms[pwmId]->ENABLE = (PWM_ENABLE_ENABLE_Disabled << PWM_ENABLE_ENABLE_Pos);
-	pwmFrequency[pwmId] = 0.;
-	pwmTopCount[pwmId]  = 0;		
+  if (pwmId>=PWM_COUNT) {
+    return;
+  }
+  //nrf_pwm_disable(pwms[pwmId]);
+  pwms[pwmId]->ENABLE = (PWM_ENABLE_ENABLE_Disabled << PWM_ENABLE_ENABLE_Pos);
+  pwmFrequency[pwmId] = 0.;
+  pwmTopCount[pwmId]  = 0;
 }
 
 /*
@@ -302,135 +301,133 @@ void deinitPwm(uint8_t pwmId)
  */
 void initPwm(uint8_t pwmId, float fFreq)
 {
-	
-	if (pwmId>=PWM_COUNT) {
-		return;
-	}
-	
-	if (fFreq!=pwmFrequency[pwmId]) {
-		uint32_t preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_1;
-		//float oFreq = fFreq;
-		if (fFreq >512.) {
-			uint32_t maxFreq = 16000000/((1<<writeResolution)-1);
-			if (fFreq>(float)maxFreq) fFreq = (float)maxFreq; //writeRes 8:62745Hz; 9:31331Hz; 10:15640Hz
-			preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_1;
-		}
-		else if (fFreq >256.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_2;
-		else if (fFreq >128.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_4;
-		else if (fFreq > 64.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_8;
-		else if (fFreq > 32.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_16;
-		else if (fFreq > 16.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_32;
-		else if (fFreq >  8.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_64;
-		else {
-			if (fFreq < 4.) fFreq = 4.;
-			preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_128;
-		}
-		float topCntValue = (float)(16000000/(1<<preScaleDiv_X)) / fFreq;	// <= 32767. (max. 15bit)!
+  if (pwmId>=PWM_COUNT) {
+    return;
+  }
 
-		//nrf_pwm_configure(pwms[pwmId], preScaleDiv_X, NRF_PWM_MODE_UP, (uint16_t)topCntValue);
-		pwms[pwmId]->PRESCALER  = preScaleDiv_X;
-        pwms[pwmId]->MODE       = PWM_MODE_UPDOWN_Up;
-        pwms[pwmId]->COUNTERTOP = (uint16_t)topCntValue;
-		
-		NRF_PWM_Type* const pwm = pwms[pwmId];
-		//nrf_pwm_enable(pwm);
-		pwm->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
+  if (fFreq!=pwmFrequency[pwmId]) {
+    uint32_t preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_1;
+    //float oFreq = fFreq;
+    if (fFreq >512.) {
+      uint32_t maxFreq = 16000000/((1<<writeResolution)-1);
+      if (fFreq>(float)maxFreq) fFreq = (float)maxFreq; //writeRes 8:62745Hz; 9:31331Hz; 10:15640Hz
+      preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_1;
+    }
+    else if (fFreq >256.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_2;
+    else if (fFreq >128.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_4;
+    else if (fFreq > 64.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_8;
+    else if (fFreq > 32.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_16;
+    else if (fFreq > 16.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_32;
+    else if (fFreq >  8.) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_64;
+    else {
+      if (fFreq < 4.) fFreq = 4.;
+      preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_128;
+    }
+    float topCntValue = (float)(16000000/(1<<preScaleDiv_X)) / fFreq;	// =< 32767. (max. 15bit)!
 
-		//nrf_pwm_loop_set   (pwm, 0);
-		pwm->LOOP = 0;
-		//nrf_pwm_decoder_set(pwm, PWM_DECODER_LOAD_Individual, NRF_PWM_STEP_AUTO);	  
-		pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Individual   << PWM_DECODER_LOAD_Pos)
-                     | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
-		//nrf_pwm_seq_ptr_set(pwm, 0, pwmChannelSequence[pwmId]);
-		pwm->SEQ[0].PTR = (uint32_t)pwmChannelSequence[pwmId];
-		//nrf_pwm_seq_cnt_set(pwm, 0, NRF_PWM_CHANNEL_COUNT);
-		pwm->SEQ[0].CNT = NRF_PWM_CHANNEL_COUNT;
-		//nrf_pwm_seq_refresh_set(pwm, 0, 1);
-		pwm->SEQ[0].REFRESH  = 1;
-		//nrf_pwm_seq_end_delay_set(pwm, 0, 0);
-		pwm->SEQ[0].ENDDELAY = 0;
-		//nrf_pwm_task_trigger(pwm, NRF_PWM_TASK_SEQSTART0);
-		//*((volatile uint32_t *)((uint8_t *)pwm + (uint32_t)NRF_PWM_TASK_SEQSTART0)) = 0x1UL;
-		pwm->TASKS_SEQSTART[0] = 0x1UL;
-		
-		pwmFrequency[pwmId] = fFreq;
-		pwmTopCount[pwmId]  = (uint16_t)topCntValue;		
-		//a_printf("pwmId:%d, of:%5.2fHz pf:%5.2fHz, T:%5d\n", pwmId, oFreq, fFreq, (uint16_t)topCntValue);
-	}
+    //nrf_pwm_configure(pwms[pwmId], preScaleDiv_X, NRF_PWM_MODE_UP, (uint16_t)topCntValue);
+    pwms[pwmId]->PRESCALER  = preScaleDiv_X;
+    pwms[pwmId]->MODE       = PWM_MODE_UPDOWN_Up;
+    pwms[pwmId]->COUNTERTOP = (uint16_t)topCntValue;
+
+    NRF_PWM_Type* const pwm = pwms[pwmId];
+    //nrf_pwm_enable(pwm);
+    pwm->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
+
+    //nrf_pwm_loop_set   (pwm, 0);
+    pwm->LOOP = 0;
+    //nrf_pwm_decoder_set(pwm, PWM_DECODER_LOAD_Individual, NRF_PWM_STEP_AUTO);	  
+    pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Individual   << PWM_DECODER_LOAD_Pos)
+                 | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
+    //nrf_pwm_seq_ptr_set(pwm, 0, pwmChannelSequence[pwmId]);
+    pwm->SEQ[0].PTR = (uint32_t)pwmChannelSequence[pwmId];
+    //nrf_pwm_seq_cnt_set(pwm, 0, NRF_PWM_CHANNEL_COUNT);
+    pwm->SEQ[0].CNT = NRF_PWM_CHANNEL_COUNT;
+    //nrf_pwm_seq_refresh_set(pwm, 0, 1);
+    pwm->SEQ[0].REFRESH  = 1;
+    //nrf_pwm_seq_end_delay_set(pwm, 0, 0);
+    pwm->SEQ[0].ENDDELAY = 0;
+    //nrf_pwm_task_trigger(pwm, NRF_PWM_TASK_SEQSTART0);
+    //*((volatile uint32_t *)((uint8_t *)pwm + (uint32_t)NRF_PWM_TASK_SEQSTART0)) = 0x1UL;
+    pwm->TASKS_SEQSTART[0] = 0x1UL;
+    
+    pwmFrequency[pwmId] = fFreq;
+    pwmTopCount[pwmId]  = (uint16_t)topCntValue;
+    //a_printf("pwmId:%d, of:%5.2fHz pf:%5.2fHz, T:%5d\n", pwmId, oFreq, fFreq, (uint16_t)topCntValue);
+  }
 }
 
 void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId)
 {
-	if (ulPin >= PINS_COUNT) {
-		return;
-	}
-	if (pwmId >= PWM_COUNT) {
-		return;
-	}
-	if (pwmFrequency[pwmId]==0) {	// frequency not set yet!
-		initPwm(pwmId, 500.); 		// also standard frequency
-	}
+  if (ulPin >= PINS_COUNT) {
+    return;
+  }
+  if (pwmId >= PWM_COUNT) {
+    return;
+  }
+  if (pwmFrequency[pwmId]==0) { // frequency not set yet!
+    initPwm(pwmId, 500.);       // also standard frequency
+  }
 
-	//uint32_t aPin = ulPin;
-	ulPin = g_ADigitalPinMap[ulPin];
-	
-	for (uint8_t ci = 0; ci < NRF_PWM_CHANNEL_COUNT; ci++) {
-		if (pwmChannelPins[pwmId][ci] == NRF_PWM_PIN_NOT_CONNECTED || 
-	        pwmChannelPins[pwmId][ci] == ulPin) {
-			
-			pwmChannelPins[pwmId][ci] = ulPin;
-			NRF_PWM_Type* const pwm = pwms[pwmId];
+  //uint32_t aPin = ulPin;
+  ulPin = g_ADigitalPinMap[ulPin];
+  
+  for (uint8_t ci = 0; ci < NRF_PWM_CHANNEL_COUNT; ci++) {
+    if (pwmChannelPins[pwmId][ci] == NRF_PWM_PIN_NOT_CONNECTED || 
+        pwmChannelPins[pwmId][ci] == ulPin) {
+    
+      pwmChannelPins[pwmId][ci] = ulPin;
+      NRF_PWM_Type* const pwm = pwms[pwmId];
 
-			//nrf_pwm_pins_set(pwm, pwmChannelPins[pwmId]);
-			for (uint8_t i = 0; i < NRF_PWM_CHANNEL_COUNT; ++i) {
-				pwm->PSEL.OUT[i] = pwmChannelPins[pwmId][i];
-			}
+      //nrf_pwm_pins_set(pwm, pwmChannelPins[pwmId]);
+      for (uint8_t i = 0; i < NRF_PWM_CHANNEL_COUNT; ++i) {
+        pwm->PSEL.OUT[i] = pwmChannelPins[pwmId][i];
+      }
 
-			//nrf_pwm_enable(pwm);
-			//pwm->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
+      //nrf_pwm_enable(pwm);
+      //pwm->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
 
-			uint32_t v = ((pwmTopCount[pwmId])*ulValue) / ((1<<writeResolution)-1);
-			v = min(v, pwmTopCount[pwmId]);
-			pwmChannelSequence[pwmId][ci] = (uint16_t)v;  // max 15bit!
-			pwmChannelSequence[pwmId][ci]|= 1<<15;        // Arduino ON/OFF duty cycle (set invert bit)
-	
-			//a_printf("pwmId:%d, aP:%2d, nP:%2d, ci:%d, v:%4d f:%5dHz T:%5d V:%5d\n", pwmId, aPin, ulPin, ci, ulValue, pwmFrequency[pwmId], pwmTopCount[pwmId], v);
-			pwm->SEQ[0].REFRESH  = 1;
-			pwm->SEQ[0].ENDDELAY = 0;
-			pwm->TASKS_SEQSTART[0] = 0x1UL;
-			/* 
-			//nrf_pwm_loop_set   (pwm, 0);
-			pwm->LOOP = 0;
-			//nrf_pwm_decoder_set(pwm, PWM_DECODER_LOAD_Individual, NRF_PWM_STEP_AUTO);	  
-			pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Individual   << PWM_DECODER_LOAD_Pos)
-                         | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
-			//nrf_pwm_seq_ptr_set(pwm, 0, pwmChannelSequence[pwmId]);
-			pwm->SEQ[0].PTR = (uint32_t)pwmChannelSequence[pwmId];
-			//nrf_pwm_seq_cnt_set(pwm, 0, NRF_PWM_CHANNEL_COUNT);
-			pwm->SEQ[0].CNT = NRF_PWM_CHANNEL_COUNT;
-			//nrf_pwm_seq_refresh_set(pwm, 0, 1);
-			pwm->SEQ[0].REFRESH  = 1;
-			//nrf_pwm_seq_end_delay_set(pwm, 0, 0);
-			pwm->SEQ[0].ENDDELAY = 0;
-			//nrf_pwm_task_trigger(pwm, NRF_PWM_TASK_SEQSTART0);
-			// *((volatile uint32_t *)((uint8_t *)pwm + (uint32_t)NRF_PWM_TASK_SEQSTART0)) = 0x1UL;
-			pwm->TASKS_SEQSTART[0] = 0x1UL;
-			*/
+      uint32_t v = ((pwmTopCount[pwmId])*ulValue) / ((1<<writeResolution)-1);
+      v = min(v, pwmTopCount[pwmId]);
+      pwmChannelSequence[pwmId][ci] = (uint16_t)v;  // max 15bit!
+      pwmChannelSequence[pwmId][ci]|= 1<<15;        // Arduino ON/OFF duty cycle (set invert bit)
+
+      //a_printf("pwmId:%d, aP:%2d, nP:%2d, ci:%d, v:%4d f:%5dHz T:%5d V:%5d\n", pwmId, aPin, ulPin, ci, ulValue, pwmFrequency[pwmId], pwmTopCount[pwmId], v);
+      pwm->SEQ[0].REFRESH  = 1;
+      pwm->SEQ[0].ENDDELAY = 0;
+      pwm->TASKS_SEQSTART[0] = 0x1UL;
+      /* 
+      //nrf_pwm_loop_set   (pwm, 0);
+      pwm->LOOP = 0;
+      //nrf_pwm_decoder_set(pwm, PWM_DECODER_LOAD_Individual, NRF_PWM_STEP_AUTO);	  
+      pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Individual   << PWM_DECODER_LOAD_Pos)
+                   | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
+      //nrf_pwm_seq_ptr_set(pwm, 0, pwmChannelSequence[pwmId]);
+      pwm->SEQ[0].PTR = (uint32_t)pwmChannelSequence[pwmId];
+      //nrf_pwm_seq_cnt_set(pwm, 0, NRF_PWM_CHANNEL_COUNT);
+      pwm->SEQ[0].CNT = NRF_PWM_CHANNEL_COUNT;
+      //nrf_pwm_seq_refresh_set(pwm, 0, 1);
+      pwm->SEQ[0].REFRESH  = 1;
+      //nrf_pwm_seq_end_delay_set(pwm, 0, 0);
+      pwm->SEQ[0].ENDDELAY = 0;
+      //nrf_pwm_task_trigger(pwm, NRF_PWM_TASK_SEQSTART0);
+      // *((volatile uint32_t *)((uint8_t *)pwm + (uint32_t)NRF_PWM_TASK_SEQSTART0)) = 0x1UL;
+      pwm->TASKS_SEQSTART[0] = 0x1UL;
+      */
 /* compare to origin:
       pwm->LOOP = 0;
       pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Common << PWM_DECODER_LOAD_Pos) 
-	               | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
+                   | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
       pwm->SEQ[0].PTR = (uint32_t)&pwmChannelSequence[i];
       pwm->SEQ[0].CNT = 1;
       pwm->SEQ[0].REFRESH  = 1;
       pwm->SEQ[0].ENDDELAY = 0;
       pwm->TASKS_SEQSTART[0] = 0x1UL;
-*/			
-			break;
-		}
-	}
+*/
+      break;
+    }
+  }
 }
-	
 #endif
 
 #ifdef __cplusplus

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -28,6 +28,9 @@
 extern "C" {
 #endif
 
+static uint32_t saadcReference = SAADC_CH_CONFIG_REFSEL_Internal;
+static uint32_t saadcGain      = SAADC_CH_CONFIG_GAIN_Gain1_5;
+
 #define PWM_COUNT 3
 
 static NRF_PWM_Type* pwms[PWM_COUNT] = {
@@ -36,22 +39,40 @@ static NRF_PWM_Type* pwms[PWM_COUNT] = {
   NRF_PWM2
 };
 
+#ifndef NEW_PWM
 static uint32_t pwmChannelPins[PWM_COUNT] = {
   0xFFFFFFFF,
   0xFFFFFFFF,
   0xFFFFFFFF
 };
-
-static uint32_t saadcReference = SAADC_CH_CONFIG_REFSEL_Internal;
-static uint32_t saadcGain      = SAADC_CH_CONFIG_GAIN_Gain1_5;
-
 static uint16_t pwmChannelSequence[PWM_COUNT];
+
+#else	// NEW-PWM ==============================
+
+#define NRF_PWM_CHANNEL_COUNT 4    
+#define NRF_PWM_PIN_NOT_CONNECTED 0xFFFFFFFF
+static uint32_t pwmFrequency[PWM_COUNT] = { 0, 0, 0 };
+static uint16_t pwmTopCount[PWM_COUNT]  = { 0, 0, 0 };
+static uint32_t pwmChannelPins[PWM_COUNT][NRF_PWM_CHANNEL_COUNT] = {
+  {NRF_PWM_PIN_NOT_CONNECTED, NRF_PWM_PIN_NOT_CONNECTED, NRF_PWM_PIN_NOT_CONNECTED,NRF_PWM_PIN_NOT_CONNECTED},
+  {NRF_PWM_PIN_NOT_CONNECTED, NRF_PWM_PIN_NOT_CONNECTED, NRF_PWM_PIN_NOT_CONNECTED,NRF_PWM_PIN_NOT_CONNECTED},
+  {NRF_PWM_PIN_NOT_CONNECTED, NRF_PWM_PIN_NOT_CONNECTED, NRF_PWM_PIN_NOT_CONNECTED,NRF_PWM_PIN_NOT_CONNECTED}
+};
+static uint16_t pwmChannelSequence[PWM_COUNT][NRF_PWM_CHANNEL_COUNT] = {
+  {0, 0, 0, 0},
+  {0, 0, 0, 0},
+  {0, 0, 0, 0}
+};
+#endif	// NEW-PWM ==============================
 
 static int readResolution = 10;
 static int writeResolution = 8;
 
 void analogReadResolution( int res )
 {
+  if (res<8)  res = 8;
+  else
+  if (res>10) res = 10;
   readResolution = res;
 }
 
@@ -208,6 +229,8 @@ uint32_t analogRead( uint32_t ulPin )
   return mapResolution(value, resolution, readResolution);
 }
 
+
+#ifndef NEW_PWM
 // Right now, PWM output only works on the pins with
 // hardware support.  These are defined in the appropriate
 // pins_*.c file.  For the rest of the pins, we default
@@ -233,11 +256,12 @@ void analogWrite( uint32_t ulPin, uint32_t ulValue )
       pwm->PSEL.OUT[2] = ulPin;
       pwm->PSEL.OUT[3] = ulPin;
       pwm->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
-      pwm->PRESCALER = PWM_PRESCALER_PRESCALER_DIV_1;
+      pwm->PRESCALER = PWM_PRESCALER_PRESCALER_DIV_2;
       pwm->MODE = PWM_MODE_UPDOWN_Up;
       pwm->COUNTERTOP = (1 << writeResolution) - 1;
       pwm->LOOP = 0;
-      pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Common << PWM_DECODER_LOAD_Pos) | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
+      pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Common << PWM_DECODER_LOAD_Pos) 		//JH initPWM?
+	               | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);	//JH initPWM?
       pwm->SEQ[0].PTR = (uint32_t)&pwmChannelSequence[i];
       pwm->SEQ[0].CNT = 1;
       pwm->SEQ[0].REFRESH  = 1;
@@ -248,6 +272,165 @@ void analogWrite( uint32_t ulPin, uint32_t ulValue )
     }
   }
 }
+#else
+// Right now, PWM output only works on the pins with
+// hardware support.  These are defined in the appropriate
+// pins_*.c file.  For the rest of the pins, we default
+// to digital output.
+extern  void a_printf(const char *fmt, ... );
+
+void analogWrite(uint32_t ulPin, uint32_t ulValue )
+{
+	if (pwmFrequency[0]==0) initPwm(0, 500);
+	analogWritePwm(ulPin, ulValue, 0);
+}
+
+void deinitPwm(uint8_t pwmId)
+{
+	if (pwmId>=PWM_COUNT) {
+		return;
+	}
+	
+	//nrf_pwm_disable(pwms[pwmId]);
+	pwms[pwmId]->ENABLE = (PWM_ENABLE_ENABLE_Disabled << PWM_ENABLE_ENABLE_Pos);
+	pwmFrequency[pwmId] = 0;
+	pwmTopCount[pwmId]  = 0;		
+}
+/*
+ *
+ */
+void initPwm(uint8_t pwmId, uint32_t ulFreq)
+{
+	
+	if (pwmId>=PWM_COUNT) {
+		return;
+	}
+	
+	if (ulFreq!=pwmFrequency[pwmId]) {
+		uint32_t preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_1;
+		uint32_t oFreq = ulFreq;
+		if (ulFreq >512) {
+			uint32_t maxFreq = 16000000/((1<<writeResolution)-1);
+			if (ulFreq>maxFreq) ulFreq = maxFreq; //writeRes 8:62745Hz; 9:31331Hz; 10:15640Hz
+			preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_1;
+		}
+		else if (ulFreq >256) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_2;
+		else if (ulFreq >128) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_4;
+		else if (ulFreq > 64) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_8;
+		else if (ulFreq > 32) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_16;
+		else if (ulFreq > 16) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_32;
+		else if (ulFreq >  8) preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_64;
+		else {
+			if (ulFreq < 4) ulFreq = 4;
+			preScaleDiv_X = PWM_PRESCALER_PRESCALER_DIV_128;
+		}
+		uint32_t topCntValue = 16000000/(ulFreq << preScaleDiv_X);	// max. 15bit! = 32767!
+
+		//nrf_pwm_configure(pwms[pwmId], preScaleDiv_X, NRF_PWM_MODE_UP, (uint16_t)topCntValue);
+		pwms[pwmId]->PRESCALER  = preScaleDiv_X;
+        pwms[pwmId]->MODE       = PWM_MODE_UPDOWN_Up;
+        pwms[pwmId]->COUNTERTOP = (uint16_t)topCntValue;
+		
+		NRF_PWM_Type* const pwm = pwms[pwmId];
+		//nrf_pwm_enable(pwm);
+		pwm->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
+
+		//nrf_pwm_loop_set   (pwm, 0);
+		pwm->LOOP = 0;
+		//nrf_pwm_decoder_set(pwm, PWM_DECODER_LOAD_Individual, NRF_PWM_STEP_AUTO);	  
+		pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Individual   << PWM_DECODER_LOAD_Pos)
+                     | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
+		//nrf_pwm_seq_ptr_set(pwm, 0, pwmChannelSequence[pwmId]);
+		pwm->SEQ[0].PTR = (uint32_t)pwmChannelSequence[pwmId];
+		//nrf_pwm_seq_cnt_set(pwm, 0, NRF_PWM_CHANNEL_COUNT);
+		pwm->SEQ[0].CNT = NRF_PWM_CHANNEL_COUNT;
+		//nrf_pwm_seq_refresh_set(pwm, 0, 1);
+		pwm->SEQ[0].REFRESH  = 1;
+		//nrf_pwm_seq_end_delay_set(pwm, 0, 0);
+		pwm->SEQ[0].ENDDELAY = 0;
+		//nrf_pwm_task_trigger(pwm, NRF_PWM_TASK_SEQSTART0);
+		//*((volatile uint32_t *)((uint8_t *)pwm + (uint32_t)NRF_PWM_TASK_SEQSTART0)) = 0x1UL;
+		pwm->TASKS_SEQSTART[0] = 0x1UL;
+		
+		pwmFrequency[pwmId] = ulFreq;
+		pwmTopCount[pwmId]  = topCntValue;		
+		//a_printf("pwmId:%d, of:%5dHz pf:%5dHz, T:%5d\n", pwmId, oFreq, ulFreq, topCntValue);
+	}
+}
+
+void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId)
+{
+	if (ulPin >= PINS_COUNT) {
+		return;
+	}
+	if (pwmId >= PWM_COUNT) {
+		return;
+	}
+	if (pwmFrequency[pwmId]==0) {	// frequency not set yet!
+		initPwm(pwmId, 500); 		// also standard frequency
+	}
+
+	uint32_t aPin = ulPin;
+	ulPin = g_ADigitalPinMap[ulPin];
+	
+	for (uint8_t ci = 0; ci < NRF_PWM_CHANNEL_COUNT; ci++) {
+		if (pwmChannelPins[pwmId][ci] == NRF_PWM_PIN_NOT_CONNECTED || 
+	        pwmChannelPins[pwmId][ci] == ulPin) {
+			
+			pwmChannelPins[pwmId][ci] = ulPin;
+			NRF_PWM_Type* const pwm = pwms[pwmId];
+
+			//nrf_pwm_pins_set(pwm, pwmChannelPins[pwmId]);
+			for (uint8_t i = 0; i < NRF_PWM_CHANNEL_COUNT; ++i) {
+				pwm->PSEL.OUT[i] = pwmChannelPins[pwmId][i];
+			}
+
+			//nrf_pwm_enable(pwm);
+			//pwm->ENABLE = (PWM_ENABLE_ENABLE_Enabled << PWM_ENABLE_ENABLE_Pos);
+
+			uint32_t v = ((pwmTopCount[pwmId])*ulValue) / ((1<<writeResolution)-1);
+			v = min(v, pwmTopCount[pwmId]);
+			pwmChannelSequence[pwmId][ci] = (uint16_t)v;  // max 15bit!
+			pwmChannelSequence[pwmId][ci]|= 1<<15;        // Arduino ON/OFF duty cycle (set invert bit)
+	
+			//a_printf("pwmId:%d, aP:%2d, nP:%2d, ci:%d, v:%4d f:%5dHz T:%5d V:%5d\n", pwmId, aPin, ulPin, ci, ulValue, pwmFrequency[pwmId], pwmTopCount[pwmId], v);
+			pwm->SEQ[0].REFRESH  = 1;
+			pwm->SEQ[0].ENDDELAY = 0;
+			pwm->TASKS_SEQSTART[0] = 0x1UL;
+			/* 
+			//nrf_pwm_loop_set   (pwm, 0);
+			pwm->LOOP = 0;
+			//nrf_pwm_decoder_set(pwm, PWM_DECODER_LOAD_Individual, NRF_PWM_STEP_AUTO);	  
+			pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Individual   << PWM_DECODER_LOAD_Pos)
+                         | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
+			//nrf_pwm_seq_ptr_set(pwm, 0, pwmChannelSequence[pwmId]);
+			pwm->SEQ[0].PTR = (uint32_t)pwmChannelSequence[pwmId];
+			//nrf_pwm_seq_cnt_set(pwm, 0, NRF_PWM_CHANNEL_COUNT);
+			pwm->SEQ[0].CNT = NRF_PWM_CHANNEL_COUNT;
+			//nrf_pwm_seq_refresh_set(pwm, 0, 1);
+			pwm->SEQ[0].REFRESH  = 1;
+			//nrf_pwm_seq_end_delay_set(pwm, 0, 0);
+			pwm->SEQ[0].ENDDELAY = 0;
+			//nrf_pwm_task_trigger(pwm, NRF_PWM_TASK_SEQSTART0);
+			// *((volatile uint32_t *)((uint8_t *)pwm + (uint32_t)NRF_PWM_TASK_SEQSTART0)) = 0x1UL;
+			pwm->TASKS_SEQSTART[0] = 0x1UL;
+			*/
+/* compare to origin:
+      pwm->LOOP = 0;
+      pwm->DECODER = ((uint32_t)PWM_DECODER_LOAD_Common << PWM_DECODER_LOAD_Pos) 
+	               | ((uint32_t)PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
+      pwm->SEQ[0].PTR = (uint32_t)&pwmChannelSequence[i];
+      pwm->SEQ[0].CNT = 1;
+      pwm->SEQ[0].REFRESH  = 1;
+      pwm->SEQ[0].ENDDELAY = 0;
+      pwm->TASKS_SEQSTART[0] = 0x1UL;
+*/			
+			break;
+		}
+	}
+}
+	
+#endif
 
 #ifdef __cplusplus
 }

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -282,7 +282,7 @@ extern  void a_printf(const char *fmt, ... );
 void analogWrite(uint32_t ulPin, uint32_t ulValue )
 {
   if (pwmFrequency[0]==0.) initPwm(0, 500.);
-  analogWritePwm(ulPin, ulValue, 0);
+  analogWritePwm(ulPin, ulValue, 0, false);
 }
 
 void deinitPwm(uint8_t pwmId)
@@ -357,7 +357,7 @@ void initPwm(uint8_t pwmId, float fFreq)
   }
 }
 
-void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId)
+void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId, bool invert)
 {
   if (ulPin >= PINS_COUNT) {
     return;
@@ -390,7 +390,9 @@ void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId)
       uint32_t v = ((pwmTopCount[pwmId])*ulValue) / ((1<<writeResolution)-1);
       v = min(v, pwmTopCount[pwmId]);
       pwmChannelSequence[pwmId][ci] = (uint16_t)v;  // max 15bit!
-      pwmChannelSequence[pwmId][ci]|= 1<<15;        // Arduino ON/OFF duty cycle (set invert bit)
+      if (!invert) { 
+        pwmChannelSequence[pwmId][ci]|= 1<<15;        // Arduino ON/OFF duty cycle (set invert bit)
+      }
 
       //a_printf("pwmId:%d, aP:%2d, nP:%2d, ci:%d, v:%4d f:%5dHz T:%5d V:%5d\n", pwmId, aPin, ulPin, ci, ulValue, pwmFrequency[pwmId], pwmTopCount[pwmId], v);
       pwm->SEQ[0].REFRESH  = 1;

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -370,7 +370,7 @@ void analogWritePwm( uint32_t ulPin, uint32_t ulValue, uint8_t pwmId)
 		initPwm(pwmId, 500); 		// also standard frequency
 	}
 
-	uint32_t aPin = ulPin;
+	//uint32_t aPin = ulPin;
 	ulPin = g_ADigitalPinMap[ulPin];
 	
 	for (uint8_t ci = 0; ci < NRF_PWM_CHANNEL_COUNT; ci++) {

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -151,7 +151,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
 
   while(!_p_twim->EVENTS_RXSTARTED && !_p_twim->EVENTS_ERROR);
   _p_twim->EVENTS_RXSTARTED = 0x0UL;
-
+  
   while(!_p_twim->EVENTS_LASTRX && !_p_twim->EVENTS_ERROR);
   _p_twim->EVENTS_LASTRX = 0x0UL;
 
@@ -213,8 +213,10 @@ uint8_t TwoWire::endTransmission(bool stopBit)
 
   while(!_p_twim->EVENTS_TXSTARTED && !_p_twim->EVENTS_ERROR);
   _p_twim->EVENTS_TXSTARTED = 0x0UL;
-
-  while(!_p_twim->EVENTS_LASTTX && !_p_twim->EVENTS_ERROR);
+  
+  uint32_t t = micros(); while((micros()-t)<40);	//bojh
+  //bojh 
+  //while(!_p_twim->EVENTS_LASTTX && !_p_twim->EVENTS_ERROR);
   _p_twim->EVENTS_LASTTX = 0x0UL;
 
   if (stopBit || _p_twim->EVENTS_ERROR)
@@ -240,15 +242,18 @@ uint8_t TwoWire::endTransmission(bool stopBit)
 
     if (error == TWIM_ERRORSRC_ANACK_Msk)
     {
+	  Serial.println("r=2");
       return 2;
     }
     else if (error == TWIM_ERRORSRC_DNACK_Msk)
     {
       return 3;
+	  Serial.println("r=3");
     }
     else
     {
       return 4;
+	  Serial.println("r=4");
     }
   }
 

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -214,9 +214,9 @@ uint8_t TwoWire::endTransmission(bool stopBit)
   while(!_p_twim->EVENTS_TXSTARTED && !_p_twim->EVENTS_ERROR);
   _p_twim->EVENTS_TXSTARTED = 0x0UL;
   
-  uint32_t t = micros(); while((micros()-t)<40);	//bojh
+  //uint32_t t = micros(); while((micros()-t)<40);	//bojh
   //bojh 
-  //while(!_p_twim->EVENTS_LASTTX && !_p_twim->EVENTS_ERROR);
+  while(!_p_twim->EVENTS_LASTTX && !_p_twim->EVENTS_ERROR);
   _p_twim->EVENTS_LASTTX = 0x0UL;
 
   if (stopBit || _p_twim->EVENTS_ERROR)

--- a/platform.txt
+++ b/platform.txt
@@ -70,7 +70,7 @@ compiler.elf2hex.extra_flags=
 # ----------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {compiler.nrf.flags} {build.lfclk_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -DCONFIG_GPIO_AS_PINRESET -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {compiler.nrf.flags} {build.lfclk_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
 recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {compiler.nrf.flags} {build.lfclk_flags} {includes} "{source_file}" -o "{object_file}"


### PR DESCRIPTION
Nordic does provide a standard mapping of a reset functionality on P.21 which is in most boards the reset button. To support the RESET button in a standard Arduino way we have to provide a c compile flag CONFIG_GPIO_AS_PINRESET.