### PR TITLE
Allow access to the 8 analog inputs (VS 6 previously).

### DIFF
--- a/variants/nRF52DK/variant.cpp
+++ b/variants/nRF52DK/variant.cpp
@@ -38,13 +38,15 @@ const uint32_t g_ADigitalPinMap[] = {
   24,
   25,
 
-  // A0 - A5
+  // A0 - A7
   3,
   4,
   28,
   29,
   30,
   31,
+  5, // AIN3 (P0.05)
+  2, // AIN0 (P0.02) / AREF
 
   // SDA, SCL
   26,
@@ -52,8 +54,5 @@ const uint32_t g_ADigitalPinMap[] = {
 
   // RX, TX
   8,
-  6,
-
-  // AREF
-  2
+  6
 };

--- a/variants/nRF52DK/variant.h
+++ b/variants/nRF52DK/variant.h
@@ -32,9 +32,9 @@ extern "C"
 #endif // __cplusplus
 
 // Number of pins defined in PinDescription array
-#define PINS_COUNT           (25u)
+#define PINS_COUNT           (26u)
 #define NUM_DIGITAL_PINS     (20u)
-#define NUM_ANALOG_INPUTS    (6u)
+#define NUM_ANALOG_INPUTS    (8u)
 #define NUM_ANALOG_OUTPUTS   (0u)
 
 // LEDs
@@ -59,25 +59,29 @@ extern "C"
 #define PIN_A3               (17)
 #define PIN_A4               (18)
 #define PIN_A5               (19)
+#define PIN_A6               (20) /* AIN3 (P0.05)        */
+#define PIN_A7               (21) /* AIN0 (P0.02) / AREF */
 
-static const uint8_t A0  = PIN_A0 ;
-static const uint8_t A1  = PIN_A1 ;
-static const uint8_t A2  = PIN_A2 ;
-static const uint8_t A3  = PIN_A3 ;
-static const uint8_t A4  = PIN_A4 ;
-static const uint8_t A5  = PIN_A5 ;
+static const uint8_t A0  = PIN_A0 ; // AIN1
+static const uint8_t A1  = PIN_A1 ; // AIN2
+static const uint8_t A2  = PIN_A2 ; // AIN4
+static const uint8_t A3  = PIN_A3 ; // AIN5
+static const uint8_t A4  = PIN_A4 ; // AIN6
+static const uint8_t A5  = PIN_A5 ; // AIN7
+static const uint8_t A6  = PIN_A6 ; // AIN3 (P0.05)
+static const uint8_t A7  = PIN_A7 ; // AIN0 (P0.02) / AREF
 #define ADC_RESOLUTION    14
 
 // Other pins
-#define PIN_AREF           (24)
+#define PIN_AREF           (21)
 static const uint8_t AREF = PIN_AREF;
 
 /*
  * Serial interfaces
  */
 // Serial
-#define PIN_SERIAL_RX       (22)
-#define PIN_SERIAL_TX       (23)
+#define PIN_SERIAL_RX       (24)
+#define PIN_SERIAL_TX       (25)
 
 /*
  * SPI Interfaces
@@ -98,8 +102,8 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
  */
 #define WIRE_INTERFACES_COUNT 1
 
-#define PIN_WIRE_SDA         (20u)
-#define PIN_WIRE_SCL         (21u)
+#define PIN_WIRE_SDA         (22u)
+#define PIN_WIRE_SCL         (23u)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi @sandeepmistry!
1st off, congrats for this amazing repo, I've been following your work for a while and it's always a pleasure to read and use your code.

About this pull request, it's a simple modification that allows accessing to all the analog pins of the nRF52.
The Arduino environment doesn't allow it by default but several forks (such as Teensy) have more analog inputs and a similar approach.
Let me know if this PR is not formatted as it should, any feedback or suggestion would be more than welcome.
Thanks again for this great project,
Cedric ;)

PS: As an example, the modification is used it here:
https://github.com/honnet/nRF52AnalogTx/blob/master/nRF52AnalogTx.ino#L14