### PR TITLE
consolidates to using .protocol instead of .interface and correct defines

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -265,8 +265,7 @@ BBCmicrobit.vid.0=0x0d28
 BBCmicrobit.pid.0=0x0204
 
 BBCmicrobit.upload.tool=sandeepmistry:openocd
-BBCmicrobit.upload.protocol=
-BBCmicrobit.upload.interface=cmsis-dap
+BBCmicrobit.upload.protocol=cmsis-dap
 BBCmicrobit.upload.target=nrf51
 BBCmicrobit.upload.maximum_size=262144
 BBCmicrobit.upload.setup_command=transport select swd;

--- a/boards.txt
+++ b/boards.txt
@@ -66,8 +66,7 @@ Blend2.vid.0=0x0204
 Blend2.pid.0=0x0d28
 
 Blend2.upload.tool=sandeepmistry:openocd
-Blend2.upload.protocol=
-Blend2.upload.interface=cmsis-dap
+Blend2.upload.protocol=cmsis-dap
 Blend2.upload.target=nrf52
 Blend2.upload.maximum_size=524288
 Blend2.upload.setup_command=transport select swd;
@@ -106,8 +105,7 @@ BLENano2.vid.0=0x0204
 BLENano2.pid.0=0x0d28
 
 BLENano2.upload.tool=sandeepmistry:openocd
-BLENano2.upload.protocol=
-BLENano2.upload.interface=cmsis-dap
+BLENano2.upload.protocol=cmsis-dap
 BLENano2.upload.target=nrf52
 BLENano2.upload.maximum_size=524288
 BLENano2.upload.setup_command=transport select swd;
@@ -146,8 +144,7 @@ nRF52DK.vid.0=0x1366
 nRF52DK.pid.0=0x1015
 
 nRF52DK.upload.tool=sandeepmistry:openocd
-nRF52DK.upload.protocol=
-nRF52DK.upload.interface=jlink
+nRF52DK.upload.protocol=jlink
 nRF52DK.upload.target=nrf52
 nRF52DK.upload.maximum_size=524288
 nRF52DK.upload.setup_command=transport select swd;
@@ -368,8 +365,7 @@ PCA1000X.build.ldscript=nrf51_xxaa.ld
 PCA1000X.build.lfclk_flags=-DUSE_LFXO
 
 PCA1000X.upload.tool=sandeepmistry:openocd
-PCA1000X.upload.protocol=
-PCA1000X.upload.interface=jlink
+PCA1000X.upload.protocol=jlink
 PCA1000X.upload.target=nrf51
 PCA1000X.upload.maximum_size=262144
 PCA1000X.upload.setup_command=transport select swd; set WORKAREASIZE 0;
@@ -407,9 +403,10 @@ PCA1000X.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT
 nRF51Dongle.name= Nordic nRF51 Dongle (PCA10031)
 
 nRF51Dongle.upload.tool=sandeepmistry:openocd
-nRF51Dongle.upload.interface=cmsisdap
+nRF51Dongle.upload.protocol=cmsis-dap
 nRF51Dongle.upload.target=nrf51
 nRF51Dongle.upload.maximum_size=262144
+nRF51Dongle.upload.setup_command=transport select swd;
 
 nRF51Dongle.bootloader.tool=sandeepmistry:openocd
 
@@ -444,6 +441,7 @@ nRF51Dongle.menu.softdevice.s130.softdeviceversion=2.0.1
 nRF51Dongle.menu.softdevice.s130.upload.maximum_size=151552
 nRF51Dongle.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 nRF51Dongle.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_{build.chip}.ld
+
 
 OSHChip.name=OSHChip
 
@@ -486,9 +484,10 @@ OSHChip.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxac.ld
 BLENano.name=RedBearLab BLE Nano
 
 BLENano.upload.tool=sandeepmistry:openocd
-BLENano.upload.interface=cmsisdap
+BLENano.upload.protocol=cmsis-dap
 BLENano.upload.target=nrf51
 BLENano.upload.maximum_size=262144
+BLENano.upload.setup_command=transport select swd;
 
 BLENano.bootloader.tool=sandeepmistry:openocd
 
@@ -530,9 +529,10 @@ BLENano.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_{build.chip}.ld
 RedBearLab_nRF51822.name=RedBearLab nRF51822
 
 RedBearLab_nRF51822.upload.tool=sandeepmistry:openocd
-RedBearLab_nRF51822.upload.interface=cmsisdap
+RedBearLab_nRF51822.upload.protocol=cmsis-dap
 RedBearLab_nRF51822.upload.target=nrf51
 RedBearLab_nRF51822.upload.maximum_size=262144
+RedBearLab_nRF51822.upload.setup_command=transport select swd;
 
 RedBearLab_nRF51822.bootloader.tool=sandeepmistry:openocd
 

--- a/platform.txt
+++ b/platform.txt
@@ -116,11 +116,11 @@ tools.openocd.cmd.windows=bin/openocd.exe
 
 tools.openocd.upload.params.verbose=-d2
 tools.openocd.upload.params.quiet=-d0
-tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -f interface/{upload.interface}.cfg -c "{upload.setup_command}" -f target/{upload.target}.cfg -c "program {{{build.path}/{build.project_name}.hex}} verify reset; shutdown;"
+tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -f interface/{upload.protool}.cfg -c "{upload.setup_command}" -f target/{upload.target}.cfg -c "program {{{build.path}/{build.project_name}.hex}} verify reset; shutdown;"
 
 tools.openocd.program.params.verbose=-d2
 tools.openocd.program.params.quiet=-d0
-tools.openocd.program.pattern="{path}/{cmd}" {program.verbose} -f interface/{program.interface}.cfg -c "{program.setup_command}" -f target/{upload.target}.cfg -c "program {{{build.path}/{build.project_name}.hex}} verify reset; shutdown;"
+tools.openocd.program.pattern="{path}/{cmd}" {program.verbose} -f interface/{program.protocol}.cfg -c "{program.setup_command}" -f target/{upload.target}.cfg -c "program {{{build.path}/{build.project_name}.hex}} verify reset; shutdown;"
 
 tools.openocd.erase.params.verbose=-d3
 tools.openocd.erase.params.quiet=-d0
@@ -128,4 +128,4 @@ tools.openocd.erase.pattern=
 
 tools.openocd.bootloader.params.verbose=-d2
 tools.openocd.bootloader.params.quiet=-d0
-tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -f interface/{program.interface}.cfg -c "{program.setup_command}" -f target/{upload.target}.cfg -c "init; halt; nrf51 mass_erase; program {{{runtime.platform.path}/cores/nRF5/SDK/components/softdevice/{softdevice}/hex/{softdevice}_{upload.target}_{softdeviceversion}_softdevice.hex}} verify reset; shutdown;"
+tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -f interface/{program.protocol}.cfg -c "{program.setup_command}" -f target/{upload.target}.cfg -c "init; halt; nrf51 mass_erase; program {{{runtime.platform.path}/cores/nRF5/SDK/components/softdevice/{softdevice}/hex/{softdevice}_{upload.target}_{softdeviceversion}_softdevice.hex}} verify reset; shutdown;"

--- a/platform.txt
+++ b/platform.txt
@@ -116,7 +116,7 @@ tools.openocd.cmd.windows=bin/openocd.exe
 
 tools.openocd.upload.params.verbose=-d2
 tools.openocd.upload.params.quiet=-d0
-tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -f interface/{upload.protool}.cfg -c "{upload.setup_command}" -f target/{upload.target}.cfg -c "program {{{build.path}/{build.project_name}.hex}} verify reset; shutdown;"
+tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -f interface/{upload.protocol}.cfg -c "{upload.setup_command}" -f target/{upload.target}.cfg -c "program {{{build.path}/{build.project_name}.hex}} verify reset; shutdown;"
 
 tools.openocd.program.params.verbose=-d2
 tools.openocd.program.params.quiet=-d0

--- a/programmers.txt
+++ b/programmers.txt
@@ -1,23 +1,20 @@
 jlink.name=J-Link
 jlink.communication=USB
-jlink.protocol=
-jlink.program.protocol=
+jlink.protocol=jlink
+jlink.program.protocol=jlink
 jlink.program.tool=openocd
-jlink.program.interface=jlink
 jlink.program.setup_command=transport select swd; set WORKAREASIZE 0;
 
 stlink.name=ST-Link V2
 stlink.communication=USB
-stlink.protocol=
-stlink.program.protocol=
+stlink.protocol=stlink-v2
+stlink.program.protocol=stlink-v2
 stlink.program.tool=openocd
-stlink.program.interface=stlink-v2
 stlink.program.setup_command=transport select hla_swd; set WORKAREASIZE 0x4000;
 
 cmsisdap.name=CMSIS-DAP
 cmsisdap.communication=USB
-cmsisdap.protocol=
-cmsisdap.program.protocol=
+cmsisdap.protocol=cmsis-dap
+cmsisdap.program.protocol=cmsis-dap
 cmsisdap.program.tool=openocd
-cmsisdap.program.interface=cmsis-dap
 cmsisdap.program.setup_command=;


### PR DESCRIPTION
I believe upload.interface is incorrect, and upload.protocol is the proper command
cmsisdap was mispelled
and cmsisdap will probably? always need swd option

See #111