### PR TITLE
Add AVR interrupt sei() and cli() macros

### DIFF
--- a/cores/nRF5/avr/interrupt.h
+++ b/cores/nRF5/avr/interrupt.h
@@ -17,7 +17,9 @@
 */
 
 /*
-  Empty file.
   This file is here to allow compatibility with sketches (made for AVR)
   that includes <AVR/interrupt.h>
 */
+
+#define sei() __enable_irq()
+#define cli() __disable_irq()


### PR DESCRIPTION
Some sketches use these AVR specific interrupt macros (sei and cli), so they can be added into `cores/nRF5/avr/interrupt.h` for compatibility.