### PR TITLE
Set CMSIS-DAP as the default uploader for the micro:bit

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -268,8 +268,14 @@ BBCmicrobit.vid.0=0x0d28
 BBCmicrobit.pid.0=0x0204
 
 BBCmicrobit.upload.tool=sandeepmistry:openocd
+BBCmicrobit.upload.protocol=
+BBCmicrobit.upload.interface=cmsis-dap
 BBCmicrobit.upload.target=nrf51
 BBCmicrobit.upload.maximum_size=262144
+BBCmicrobit.upload.setup_command=transport select swd;
+BBCmicrobit.upload.use_1200bps_touch=false
+BBCmicrobit.upload.wait_for_upload_port=false
+BBCmicrobit.upload.native_usb=false
 
 BBCmicrobit.bootloader.tool=sandeepmistry:openocd
 


### PR DESCRIPTION
Since the micro:bit comes with a DAPLink uC, we can configure CMSIS-DAP as the default uploader.