### PR TITLE
Add SDA and SCL pin constants to variant definitions.

### DIFF
--- a/variants/BBCmicrobit/variant.h
+++ b/variants/BBCmicrobit/variant.h
@@ -94,6 +94,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (20u)
 #define PIN_WIRE_SCL         (19u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/BLENano/variant.h
+++ b/variants/BLENano/variant.h
@@ -88,6 +88,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (2u)
 #define PIN_WIRE_SCL         (3u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/BluzDK/variant.h
+++ b/variants/BluzDK/variant.h
@@ -107,6 +107,9 @@ static const uint8_t SCK1  = PIN_SPI1_SCK ;
 #define PIN_WIRE_SDA         (0u)
 #define PIN_WIRE_SCL         (1u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/Generic/variant.h
+++ b/variants/Generic/variant.h
@@ -96,6 +96,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (20u)
 #define PIN_WIRE_SCL         (21u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/PCA1000X/variant.h
+++ b/variants/PCA1000X/variant.h
@@ -110,6 +110,9 @@ extern "C"
   #define PIN_WIRE_SDA         (25u)
   #define PIN_WIRE_SCL         (24u)
 
+  static const uint8_t SDA = PIN_WIRE_SDA;
+  static const uint8_t SCL = PIN_WIRE_SCL;
+
 #else
   /* PCA10000
    * *********/

--- a/variants/RedBearLab_nRF51822/variant.h
+++ b/variants/RedBearLab_nRF51822/variant.h
@@ -88,6 +88,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (20u)
 #define PIN_WIRE_SCL         (21u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/RedBear_BLENano2/variant.h
+++ b/variants/RedBear_BLENano2/variant.h
@@ -87,6 +87,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (2u)
 #define PIN_WIRE_SCL         (3u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/RedBear_Blend2/variant.h
+++ b/variants/RedBear_Blend2/variant.h
@@ -91,6 +91,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (20u)
 #define PIN_WIRE_SCL         (21u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/Taida_Century_nRF52_minidev/variant.h
+++ b/variants/Taida_Century_nRF52_minidev/variant.h
@@ -101,6 +101,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (2u)
 #define PIN_WIRE_SCL         (3u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/Waveshare_BLE400/variant.h
+++ b/variants/Waveshare_BLE400/variant.h
@@ -104,6 +104,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (0u)
 #define PIN_WIRE_SCL         (1u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/nRF52DK/variant.h
+++ b/variants/nRF52DK/variant.h
@@ -105,6 +105,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (22u)
 #define PIN_WIRE_SCL         (23u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif

--- a/variants/ng-beacon/variant.h
+++ b/variants/ng-beacon/variant.h
@@ -80,6 +80,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 #define PIN_WIRE_SDA         (6u)
 #define PIN_WIRE_SCL         (7u)
 
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
So that arduino sketches can refer directly to `SDA` and `SCL` pins.

I've only added these variables to variants with `PIN_WIRE_SDA` and `PIN_WIRE_SCL` already defined, although one or two already had them.