### PR TITLE
Fix nRF51 I2C read operation

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -28,9 +28,7 @@
 
 #include "RingBuffer.h"
 
-#define BUFFER_LENGTH 32
-
- // WIRE_HAS_END means Wire has end()
+// WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
 class TwoWire : public Stream
@@ -91,7 +89,7 @@ class TwoWire : public Stream
     // RX Buffer
     RingBuffer rxBuffer;
 
-    //TX buffer
+    // TX buffer
     RingBuffer txBuffer;
     uint8_t txAddress;
 

--- a/libraries/Wire/Wire_nRF51.cpp
+++ b/libraries/Wire/Wire_nRF51.cpp
@@ -36,7 +36,7 @@ TwoWire::TwoWire(NRF_TWI_Type * p_twi, IRQn_Type IRQn, uint8_t pinSDA, uint8_t p
   this->_IRQn = IRQn;
   this->_uc_pinSDA = g_ADigitalPinMap[pinSDA];
   this->_uc_pinSCL = g_ADigitalPinMap[pinSCL];
-  transmissionBegun = false;
+  this->transmissionBegun = false;
 }
 
 void TwoWire::begin(void) {
@@ -55,7 +55,7 @@ void TwoWire::begin(void) {
                                 | ((uint32_t)GPIO_PIN_CNF_DRIVE_S0D1       << GPIO_PIN_CNF_DRIVE_Pos)
                                 | ((uint32_t)GPIO_PIN_CNF_SENSE_Disabled   << GPIO_PIN_CNF_SENSE_Pos);
 
-  _p_twi->FREQUENCY = TWI_FREQUENCY_FREQUENCY_K100;
+  _p_twi->FREQUENCY = (TWI_FREQUENCY_FREQUENCY_K100 << TWI_FREQUENCY_FREQUENCY_Pos);
   _p_twi->ENABLE = (TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos);
   _p_twi->PSELSCL = _uc_pinSCL;
   _p_twi->PSELSDA = _uc_pinSDA;
@@ -83,7 +83,7 @@ void TwoWire::setClock(uint32_t baudrate) {
     frequency = TWI_FREQUENCY_FREQUENCY_K400;
   }
 
-  _p_twi->FREQUENCY = frequency;
+  _p_twi->FREQUENCY = (frequency << TWI_FREQUENCY_FREQUENCY_Pos);
   _p_twi->ENABLE = (TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos);
 }
 
@@ -93,22 +93,34 @@ void TwoWire::end() {
 
 uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
 {
-  if(quantity == 0)
+  if (quantity == 0)
   {
     return 0;
+  }
+  if (quantity > SERIAL_BUFFER_SIZE)
+  {
+    quantity = SERIAL_BUFFER_SIZE;
   }
 
   size_t byteRead = 0;
   rxBuffer.clear();
 
   _p_twi->ADDRESS = address;
-
+  _p_twi->SHORTS = 0x1UL;    // To trigger suspend task when a byte is received
   _p_twi->TASKS_RESUME = 0x1UL;
   _p_twi->TASKS_STARTRX = 0x1UL;
 
-  for (size_t i = 0; i < quantity; i++)
+  for (byteRead = 0; byteRead < quantity; byteRead++)
   {
-    while(!_p_twi->EVENTS_RXDREADY && !_p_twi->EVENTS_ERROR);
+    if (byteRead == quantity - 1)
+    {
+      // To trigger stop task when last byte is received, set before resume task.
+      _p_twi->SHORTS = 0x2UL;
+    }
+
+    _p_twi->TASKS_RESUME = 0x1UL;
+
+    while (!_p_twi->EVENTS_RXDREADY && !_p_twi->EVENTS_ERROR);
 
     if (_p_twi->EVENTS_ERROR)
     {
@@ -118,8 +130,6 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
     _p_twi->EVENTS_RXDREADY = 0x0UL;
 
     rxBuffer.store_char(_p_twi->RXD);
-
-    _p_twi->TASKS_RESUME = 0x1UL;
   }
 
   if (stopBit || _p_twi->EVENTS_ERROR)
@@ -164,11 +174,11 @@ void TwoWire::beginTransmission(uint8_t address) {
 //  4 : Other error
 uint8_t TwoWire::endTransmission(bool stopBit)
 {
-  transmissionBegun = false ;
+  transmissionBegun = false;
 
   // Start I2C transmission
   _p_twi->ADDRESS = txAddress;
-
+  _p_twi->SHORTS = 0x0UL;
   _p_twi->TASKS_RESUME = 0x1UL;
   _p_twi->TASKS_STARTTX = 0x1UL;
 


### PR DESCRIPTION
I've been having issues reading I2C data using the TWI driver. In the smallest test case
I was reading 2 individual bytes one after another in a loop and the data returned from the 'Wire.read()' was in the incorrect order.

The operation itself is very simple, send a write command selecting the register to be read and then read a single byte back. The operation should read register `0` with value `0x40` and then register `1` with value `0x00`, as shown in the image below. The bus looks exactly the same with and without this patch, but without it the software was returning the value of register `0` as `0x00` and register `1` as `0x40`.

![image](https://cloud.githubusercontent.com/assets/4189262/24766344/d6d13964-1af2-11e7-9eda-fd1a7e86f6f9.png)

The fix is achieved by enabling during read the shortcut between the "byte boundary event" and the "suspend task" for each read byte (so when it receives a byte it triggers the hw suspend until we manually resume operation in the read loop), except for the last one, which has the byte boundary event and stop task shortcut. This is the same approach followed by the NRF sdk implementation.

Apart from that TwoWire::requestFrom() wasn't really returning the number of bytes read, so that is fixed as well, together with a clamp on input argument `quantity`, so that the number of bytes to read cannot be larger than the size of the rx ring buffer.