### PR TITLE
Remove unused interrupt from nRF51 Wire lib

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -39,7 +39,7 @@ class TwoWire : public Stream
 #ifdef NRF52
     TwoWire(NRF_TWIM_Type * p_twim, NRF_TWIS_Type * p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
 #else
-    TwoWire(NRF_TWI_Type * p_twi, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
+    TwoWire(NRF_TWI_Type * p_twi, uint8_t pinSDA, uint8_t pinSCL);
 #endif
     void begin();
 #ifdef NRF52
@@ -65,11 +65,10 @@ class TwoWire : public Stream
 #ifdef NRF52
     void onReceive(void(*)(int));
     void onRequest(void(*)(void));
+    void onService(void);
 #endif
 
     using Print::write;
-
-    void onService(void);
 
   private:
 #ifdef NRF52

--- a/libraries/Wire/Wire_nRF51.cpp
+++ b/libraries/Wire/Wire_nRF51.cpp
@@ -30,10 +30,9 @@ extern "C" {
 
 #include "Wire.h"
 
-TwoWire::TwoWire(NRF_TWI_Type * p_twi, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL)
+TwoWire::TwoWire(NRF_TWI_Type * p_twi, uint8_t pinSDA, uint8_t pinSCL)
 {
   this->_p_twi = p_twi;
-  this->_IRQn = IRQn;
   this->_uc_pinSDA = g_ADigitalPinMap[pinSDA];
   this->_uc_pinSCL = g_ADigitalPinMap[pinSCL];
   transmissionBegun = false;
@@ -59,10 +58,6 @@ void TwoWire::begin(void) {
   _p_twi->ENABLE = (TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos);
   _p_twi->PSELSCL = _uc_pinSCL;
   _p_twi->PSELSDA = _uc_pinSDA;
-
-  NVIC_ClearPendingIRQ(_IRQn);
-  NVIC_SetPriority(_IRQn, 2);
-  NVIC_EnableIRQ(_IRQn);
 }
 
 void TwoWire::setClock(uint32_t baudrate) {
@@ -277,20 +272,8 @@ void TwoWire::flush(void)
   // data transfer.
 }
 
-void TwoWire::onService(void)
-{
-}
-
 #if WIRE_INTERFACES_COUNT > 0
-TwoWire Wire(NRF_TWI1, SPI1_TWI1_IRQn, PIN_WIRE_SDA, PIN_WIRE_SCL);
-
-extern "C"
-{
-  void SPI1_TWI1_IRQHandler(void)
-  {
-    Wire.onService();
-  }
-}
+TwoWire Wire(NRF_TWI1, PIN_WIRE_SDA, PIN_WIRE_SCL);
 #endif
 
 #endif


### PR DESCRIPTION
As the nRF51 TWI implementation is master only and is not interrupt driven, there is no need to have any of the interrupt code present in this version.
Also, since the constructor signature is already different to the nRF52 version, is not like it could be kept for compatibility reasons.