### PR TITLE
Fix ADC prescaler reg config, add prescaler options

### DIFF
--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /*
- * \brief SAMD products have only one reference for ADC
+ * \brief nRF51 and nRF52 have different reference options.
  */
 #ifdef NRF52
 typedef enum _eAnalogReference

--- a/cores/nRF5/wiring_analog_nRF51.c
+++ b/cores/nRF5/wiring_analog_nRF51.c
@@ -48,6 +48,7 @@ static struct PWMContext pwmContext[PWM_COUNT] = {
 static int timerEnabled = 0;
 
 static uint32_t adcReference = ADC_CONFIG_REFSEL_VBG;
+static uint32_t adcPrescaling = ADC_CONFIG_INPSEL_AnalogInputOneThirdPrescaling;
 
 static uint32_t readResolution = 10;
 static uint32_t writeResolution = 8;
@@ -80,10 +81,11 @@ static inline uint32_t mapResolution( uint32_t value, uint32_t from, uint32_t to
 }
 
 /*
- * Internal Reference is at 1.0v
- * External Reference should be between 1v and VDDANA-0.6v=2.7v
+ * Internal VBG Reference is 1.2 V.
+ * External References AREF0 and AREF1 should be between 0.83 V - 1.3 V.
  *
- * Warning : On Arduino Zero board the input/output voltage for SAMD21G18 is 3.3 volts maximum
+ * Warning : ADC should not be exposed to > 2.4 V, calculated after prescaling.
+ *           GPIO pins must not be exposed to higher voltage than VDD + 0.3 V.
  */
 void analogReference( eAnalogReference ulMode )
 {
@@ -91,23 +93,34 @@ void analogReference( eAnalogReference ulMode )
     case AR_DEFAULT:
     case AR_VBG:
     default:
+      // 1.2 Reference, 1/3 prescaler = 0 V - 3.6 V range
+      // Minimum VDD for full range in safe operation = 3.3V
       adcReference = ADC_CONFIG_REFSEL_VBG;
+      adcPrescaling = ADC_CONFIG_INPSEL_AnalogInputOneThirdPrescaling;
       break;
 
     case AR_SUPPLY_ONE_HALF:
+      // 1/2 VDD Reference, 2/3 prescaler = 0 V - 0.75VDD range
       adcReference = ADC_CONFIG_REFSEL_SupplyOneHalfPrescaling;
+      adcPrescaling = ADC_CONFIG_INPSEL_AnalogInputTwoThirdsPrescaling;
       break;
 
     case AR_SUPPLY_ONE_THIRD:
+      // 1/3 VDD Reference, 1/3 prescaler = 0 V - VDD range
       adcReference = ADC_CONFIG_REFSEL_SupplyOneThirdPrescaling;
+      adcPrescaling = ADC_CONFIG_INPSEL_AnalogInputOneThirdPrescaling;
       break;
 
     case AR_EXT0:
+      // ARF0 reference, 2/3 prescaler = 0 V - 1.5 ARF0
       adcReference = ADC_CONFIG_REFSEL_External | (ADC_CONFIG_EXTREFSEL_AnalogReference0 << ADC_CONFIG_EXTREFSEL_Pos);
+      adcPrescaling = ADC_CONFIG_INPSEL_AnalogInputTwoThirdsPrescaling;
       break;
 
     case AR_EXT1:
+      // ARF1 reference, 2/3 prescaler = 0 V - 1.5 ARF1
       adcReference = (ADC_CONFIG_REFSEL_External | ADC_CONFIG_EXTREFSEL_AnalogReference1 << ADC_CONFIG_EXTREFSEL_Pos);
+      adcPrescaling = ADC_CONFIG_INPSEL_AnalogInputTwoThirdsPrescaling;
       break;
   }
 }
@@ -178,7 +191,7 @@ uint32_t analogRead( uint32_t ulPin )
   uint32_t config_reg = 0;
 
   config_reg |= ((uint32_t)adcResolution << ADC_CONFIG_RES_Pos) & ADC_CONFIG_RES_Msk;
-  config_reg |= ((uint32_t)ADC_CONFIG_RES_10bit << ADC_CONFIG_INPSEL_Pos) & ADC_CONFIG_INPSEL_Msk;
+  config_reg |= ((uint32_t)adcPrescaling << ADC_CONFIG_INPSEL_Pos) & ADC_CONFIG_INPSEL_Msk;
   config_reg |= ((uint32_t)adcReference << ADC_CONFIG_REFSEL_Pos) & ADC_CONFIG_REFSEL_Msk;
 
   if (adcReference & ADC_CONFIG_EXTREFSEL_Msk)


### PR DESCRIPTION
So, during my tests I noticed that my ADC readings were a bit off. Basically on a voltage of around 3.27v where I would expect the ADC value to be close to the maximum of 10-bit range I was instead reading values slightly above 900.

So for default ADC configuration, the first thing to note is the macro used to set `ADC_CONFIG_INPSEL` was assigning a `ADC_CONFIG_RES` value instead of one of the INPSEL ones. This value, happended to be the same as having 1/3 prescaler on the input signal (so in this case my 3.27v input would be scaled to 1/3 of its value before reaching the ADC comparator). The `ADC_CONFIG_REFSEL` value was then set to the internal voltage reference, which is 1.2V, so in essence, together with the prescaler the ADC was configured to read voltages from 0 to 3.6V. I guess this is fine once you know it, but maybe it's not an ideal configuration taking in consideration a lot of the boards have been designed for 3.3V general operation.

Following one of the PRs for the nRF52 I've added local global to contain a prescaler value to be configured as part of the `analogReference()` set-ups. I've fixed some of the invalid comments and added a few more to easily see the values I have set up in this PR, which I do consider be the safest assumption as to what the user would expect, but of course maybe there are better options, so these should be open for discussion.

I'd like to also emphasise that this PR, as it currently stands, is not changing the default ADC behaviour, but I do very strongly suggest to change this default configuration from what it is right now (1.2V internal reference, 1/3 input prescaler), to the `AR_SUPPLY_ONE_THIRD` configuration.

This `AR_SUPPLY_ONE_THIRD` config should set up the reference voltage to be 1/3 VDD and the input voltage to 1/3 as well, therefore having an ADC range from 0 to VDD. In most boards this would be 0 to 3.3V and I do believe that's what most people would expect out of the box.