### PR TITLE
Fix minor markup error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ No additional setup required.
 
 ##### Linux
 
-For 64-bit Linux users,  ```libc6:i386```, ```libstdc++6:i386```, ```libncurses5:i386```` and ```libudev1:i386``` need to be installed :
+For 64-bit Linux users,  ```libc6:i386```, ```libstdc++6:i386```, ```libncurses5:i386``` and ```libudev1:i386``` need to be installed :
   * ```sudo dpkg --add-architecture i386```
   * ```sudo apt-get update```
   * ```sudo apt-get install libc6:i386 libstdc++6:i386 libncurses5:i386 libudev1:i386```    


### PR DESCRIPTION
The previous markdown renders as:

For 64-bit Linux users,  ```libc6:i386```, ```libstdc++6:i386```, ```libncurses5:i386```` and ```libudev1:i386``` need to be installed :