### PR TITLE
Use falling edge polarity for PWM to match standard Arduino

### DIFF
--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -222,7 +222,7 @@ void analogWrite( uint32_t ulPin, uint32_t ulValue )
   for (int i = 0; i < PWM_COUNT; i++) {
     if (pwmChannelPins[i] == 0xFFFFFFFF || pwmChannelPins[i] == ulPin) {
       pwmChannelPins[i] = ulPin;
-      pwmChannelSequence[i] = ulValue;
+      pwmChannelSequence[i] = ulValue | bit(15);
 
       NRF_PWM_Type* pwm = pwms[i];
 


### PR DESCRIPTION
I'm not 100% sure this PR is correct, I've only got anecdotal evidence, haven't been able to find anything concrete that says this is correct, but I believe it to be.

Tried using `analogWrite` to power an LED and found that it seemed inverted - a value of 255 turned the LED off and 0 turned it full on. As per [Arduino documentation](https://www.arduino.cc/en/Reference/AnalogWrite) 255 should be "always on".

The 15th bit in the PWM value [controls polarity](http://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52832.ps.v1.1%2Fpwm.html) on the nRF52. Setting this to 1 made the LED act as expected. In the Adafruit core, they have an `inverted` argument which defaults to `false` and [sets the polarity to falling edge](https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/master/cores/nRF5/HardwarePWM.cpp#L152) and their `analogWrite` uses this default of `false`. So this PR matches the Adafruit core.