### PR TITLE
Added support for the Arduino Primo Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Does not require a custom bootloader on the device.
  * [RedBear Blend 2](https://github.com/redbear/nRF5x#blend-2)
  * [RedBear Nano 2](https://github.com/redbear/nRF5x#ble-nano-2)
  * [Bluey](https://github.com/electronut/ElectronutLabs-bluey)
+ * [Arduino Primo Core](https://store.arduino.cc/arduino-primo-core)
 
 ### nRF51
  * [Plain nRF51 MCU](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822)

--- a/boards.txt
+++ b/boards.txt
@@ -252,6 +252,37 @@ STCT_nRF52_minidev.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51
 STCT_nRF52_minidev.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
 
 
+Arduino_Primo_Core.name=Arduino Primo Core
+
+Arduino_Primo_Core.upload.tool=sandeepmistry:openocd
+Arduino_Primo_Core.upload.target=nrf52
+Arduino_Primo_Core.upload.maximum_size=524288
+
+Arduino_Primo_Core.bootloader.tool=sandeepmistry:openocd
+
+Arduino_Primo_Core.build.mcu=cortex-m4
+Arduino_Primo_Core.build.f_cpu=16000000
+Arduino_Primo_Core.build.board=PRIMO_CORE
+Arduino_Primo_Core.build.core=nRF5
+Arduino_Primo_Core.build.variant=PrimoCore
+Arduino_Primo_Core.build.variant_system_lib=
+Arduino_Primo_Core.build.extra_flags=-DNRF52
+Arduino_Primo_Core.build.float_flags=-mfloat-abi=hard -mfpu=fpv4-sp-d16
+Arduino_Primo_Core.build.ldscript=nrf52_xxaa.ld
+
+Arduino_Primo_Core.menu.softdevice.none=None
+Arduino_Primo_Core.menu.softdevice.none.softdevice=none
+Arduino_Primo_Core.menu.softdevice.none.softdeviceversion=
+
+Arduino_Primo_Core.menu.softdevice.s132=S132
+Arduino_Primo_Core.menu.softdevice.s132.softdevice=s132
+Arduino_Primo_Core.menu.softdevice.s132.softdeviceversion=2.0.1
+Arduino_Primo_Core.menu.softdevice.s132.upload.maximum_size=409600
+Arduino_Primo_Core.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+Arduino_Primo_Core.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
+
+
+
 # nRF51 variants
 ###################
 

--- a/variants/PrimoCore/pins_arduino.h
+++ b/variants/PrimoCore/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/PrimoCore/variant.cpp
+++ b/variants/PrimoCore/variant.cpp
@@ -1,0 +1,144 @@
+/*
+  Copyright (c) 2016 Arduino Srl.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
+ *
+ * | Pin number |  PRIMO Board pin |  PIN   | Label/Name      |
+ * +------------+------------------+--------+-----------------+
+ * |            | Digital          |        |                 |
+ * +------------+------------------+--------+-----------------+
+ * | 0          | D0               |  P031  |                 |
+ * | 1          | D1               |  P030  |                 |
+ * | 2          | D2               |  P029  |                 |
+ * | 3          | D3               |  P028  |                 |
+ * | 4          | D4               |  P002  |                 |
+ * | 5          | D5               |  P003  |                 |
+ * | 6          | D6               |  P004  |                 |
+ * | 7          | D7               |  P005  |                 |
+ * | 8          | D8               |  P023  |                 |
+ * | 9          | D9               |  P022  |                 | 
+ * +------------+------------------+--------+-----------------+
+ * |            | LEDs             |        |                 |
+ * +------------+------------------+--------+-----------------+
+ * | 10         | 8                |  P008  | USER LED        |
+ * | 11         | 9                |  P025  | RED LED         |
+ * | 12         | 10               |  P026  | GREEN LED       |
+ * | 13         | 11               |  P027  | BLUE LED        |
+ * +------------+------------------+--------+-----------------+
+ * |            | UART             |        |                 |
+ * +------------+------------------+--------+-----------------+
+ * | 14         | TX               |  P011  |                 |
+ * | 15         | RX               |  P012  |                 |
+ * +------------+------------------+--------+-----------------+
+ * |            | I2C              |        |                 |
+ * +------------+------------------+--------+-----------------+
+ * | 16         | SDA              |  P013  |                 |
+ * | 17         | SCL              |  P014  |                 |
+ * | 18         | SDA1(SDA2)       |  P015  |                 |
+ * | 19         | SCL1(SCL2)       |  P016  |                 |
+ * +------------+------------------+--------+-----------------+
+ * |            | INT              |        |                 |
+ * +------------+------------------+--------+-----------------+
+ * | 20         | INT              |  P024  |                 |
+ * | 21         | INT1             |  P020  |                 |
+ * | 22         | INT2             |  P019  |                 |
+ * | 23         | INT3             |  P006  |                 |
+ * | 24         | INT4             |  P007  |                 |
+ * +------------+------------------+--------+-----------------+
+ * |            | TEST POINT       |        |                 |
+ * +------------+------------------+--------+-----------------+
+ * | 25         |                  |  P017  | TP4             |
+ * | 26         |                  |  P018  | TP5             |
+ * +------------+------------------+--------+-----------------+
+ * |            | NFC              |        |                 |
+ * +------------+------------------+--------+-----------------+
+ * | 27         |                  |  P009  | NFC1            |
+ * | 28         |                  |  P010  | NFC2            |
+ * +------------+------------------+--------+-----------------+
+ * |            | 32.768KHz Crystal|        |                 |
+ * +------------+------------------+--------+-----------------+
+ * |            |                  |  P000  | XL1             | 
+ * |            |                  |  P001  | XL2             | 
+ * +------------+------------------+--------+-----------------+
+ */
+
+#include "variant.h"
+
+/*
+ * Pins descriptions
+ */
+//const PinDescription g_APinDescription[]=
+const uint32_t g_ADigitalPinMap[] = 
+{
+  // 0 .. 9 - Digital pins
+  // ----------------------
+  // 0..9
+  31, // { PORT0,  31, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), ADC_A5, PWM0, NOT_ON_TIMER},
+  30, // { PORT0,  30, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), ADC_A4, PWM1, NOT_ON_TIMER},
+  29, // { PORT0,  29, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), ADC_A3, PWM2, NOT_ON_TIMER},
+  28, // { PORT0,  28, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), ADC_A2, PWM3, NOT_ON_TIMER},
+  2, // { PORT0,  2, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), ADC_A6, PWM4, NOT_ON_TIMER},
+  3, // { PORT0,  3, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), ADC_A0, PWM5, NOT_ON_TIMER},
+  4, // { PORT0,  4, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), ADC_A1, PWM6, NOT_ON_TIMER},
+  5, // { PORT0,  5, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), ADC_A7, PWM7, NOT_ON_TIMER},
+  23, // { PORT0,  23, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), No_ADC_Channel, PWM8, NOT_ON_TIMER},
+  22, // { PORT0,  22, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), No_ADC_Channel, PWM9, NOT_ON_TIMER},
+
+  // 10 .. 13 - LEDs
+  // --------------------
+  8, // { PORT0,  8, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), No_ADC_Channel, PWM10, NOT_ON_TIMER},    //USER_LED
+  25, // { PORT0,  25, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), No_ADC_Channel, PWM11, NOT_ON_TIMER},   //RED_LED
+  26, // { PORT0,  26, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), No_ADC_Channel, PWM11, NOT_ON_TIMER},  //GREEN_LED
+  27, // { PORT0,  27, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), No_ADC_Channel, PWM11, NOT_ON_TIMER},  //BLUE_LED
+
+  // 14..15 - UART (Serial)
+  // --------------------
+  11, // { PORT0, 11, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // TX
+  12, // { PORT0, 12, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // RX
+
+  // 16..17 I2C pins (SDA/SCL)
+  // ----------------------
+  13, // { PORT0,  13, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER }, // SDA
+  14, // { PORT0,  14, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER }, // SCL
+
+  // 18..19 I2C pins (SDA1/SCL1)
+  // ----------------------
+  15, // { PORT0,  15, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER }, // SDA1
+  16, // { PORT0,  16, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER }, // SCL1
+
+  // 20..24 - INT
+  // --------------------
+  24, // { PORT0, 24, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // INT
+  20, // { PORT0, 20, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // INT1
+  19, // { PORT0, 19, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // INT2
+  6, // { PORT0, 6, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // INT3
+  7, // { PORT0, 7, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // INT4
+  
+  // 25..26 - TEST POINT
+  // --------------------
+  17, // { PORT0, 17, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // TP4
+  18, // { PORT0, 18, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // TP5
+  
+  //27..28 - NFC
+  // --------------------
+  9, // { PORT0, 9, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER}, // NFC1
+  10, // { PORT0, 10, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER} // NFC2
+
+} ;
+
+//Uart Serial(14, 15);

--- a/variants/PrimoCore/variant.h
+++ b/variants/PrimoCore/variant.h
@@ -1,0 +1,143 @@
+/*
+  Copyright (c) 2016 Arduino Srl.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_ARDUINO_PRIMO_CORE_
+#define _VARIANT_ARDUINO_PRIMO_CORE_
+
+/*----------------------------------------------------------------------------
+ *        Definitions
+ *----------------------------------------------------------------------------*/
+
+
+/** Frequency of the board main oscillator */
+#define VARIANT_MAINOSC     (32768ul)
+
+/** Master clock frequency */
+#define VARIANT_MCK         (64000000ul)
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+//#ifdef __cplusplus
+// #include "Uart.h"
+//#endif // __cplusplus
+
+ #ifdef __cplusplus
+extern "C"{
+#endif // __cplusplus
+
+/**
+ * Libc porting layers
+ */
+//#if defined (  __GNUC__  )
+//#    include <syscalls.h> /** RedHat Newlib minimal stub */
+//#endif
+
+/*----------------------------------------------------------------------------
+ *        Pins
+ *----------------------------------------------------------------------------*/
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (16u)
+#define NUM_DIGITAL_PINS     (8u)
+
+//#define digitalPinToPort(P)        ( NRF_P0 )
+//#define digitalPinToBitMask(P)     ( 1 << g_APinDescription[P].ulPin )
+//#define digitalPinToTimer(P)       ( )
+//#define portOutputRegister(port)   ( &(port->OUT) )
+//#define portInputRegister(port)    ( &(port->IN)  )
+//#define portModeRegister(port)     ( &(port->DIR) )
+//#define analogInPinToBit(P)        ( g_APinDescription[P].ulPin )
+//#define digitalPinHasPWM(P)        ( g_APinDescription[P].ulPWMChannel != NOT_ON_PWM )
+//#define digitalPinToInterrupt(P)   ( P )
+
+#define USER_LED             (10u)
+#define RED_LED              (11u)
+#define GREEN_LED            (12u)
+#define BLUE_LED             (13u)
+
+#define LED_BUILTIN          USER_LED
+#define BLE_LED              BLUE_LED
+
+/*
+ * Serial interfaces
+ */
+// Serial
+#define PIN_SERIAL_RX       (15)
+#define PIN_SERIAL_TX       (14)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+
+// pins' definition can be overwritten using SPI library
+#define PIN_SPI_MOSI         (4u)
+#define PIN_SPI_MISO         (5u)
+#define PIN_SPI_SCK          (6u)
+
+static const uint8_t SS	  = 7;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK  = PIN_SPI_SCK;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 2
+
+#define PIN_WIRE_SDA         (16u)
+#define PIN_WIRE_SCL         (17u)
+
+#define PIN_WIRE_SDA1        (18u)
+#define PIN_WIRE_SCL1        (19u)
+
+/*
+ * Analog pins
+ */
+static const uint8_t A0  = 0;
+static const uint8_t A1  = 1;
+static const uint8_t A2  = 2;
+static const uint8_t A3  = 3;
+static const uint8_t A4  = 4;
+static const uint8_t A5  = 5;
+static const uint8_t A6  = 6;
+static const uint8_t A7  = 7;
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+#ifdef __cplusplus
+
+//extern Uart Serial;
+
+#endif
+
+#define SERIAL_PORT_MONITOR         Serial
+
+#endif /* _VARIANT_ARDUINO_PRIMO_CORE_ */


### PR DESCRIPTION
Added support for the Arduino Primo Core. Basically grabbed Arduino.org's pin map from https://github.com/arduino-org/arduino-core-nrf52.