### PR TITLE
Fix bug #169

### DIFF
--- a/cores/nRF5/wiring_private.h
+++ b/cores/nRF5/wiring_private.h
@@ -26,9 +26,26 @@
 extern "C" {
 #endif
 
-
 #include "wiring_constants.h"
 
+#define PWM_COUNT 3
+#define PWM_TIMER_COUNT 1 // 3 channels of TIMER1 are used. TIMER2 also could be used for PWM
+#define PIN_FREE 0xffffffff
+
+struct PWMContext {
+  uint32_t pin;
+  uint32_t value;
+  #ifdef NRF51
+  uint32_t channel;
+  uint32_t mask;
+  uint32_t event;
+  #endif
+};
+
+struct PWMStatus {
+  int8_t numActive;
+  int8_t irqNumber;
+};
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
wiring_analog_* : fallback to digitalWrite if no available PWM channel (copied from AVR core)
wiring_analog_nRF52.c : convert pwmChannelPins & pwmChannelSequence -> pwmContext to semi-standardise pwm pin allocation and pwm status between nRF51 and nRF52
wiring_private.h : Move pwm structures defines out of wiring_analog_* into wiring_private and make the instantiation of these structure externs instead of statics
wiring_digital.c : disable the appropriate pwm timer when a digitalWrite is sent to an allocated (from analogWrite) pwm pin, and free up the pwm channel for re-allocation