### PR TITLE
Black magic probe issue #183

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ For 64-bit Linux users,  ```libc6:i386```, ```libstdc++6:i386```, ```libncurses5
 
 __NOTE__: To roll back to the original driver go to: Device Manager -> Right click on device -> Check box for "Delete the driver software for this device" and click Uninstall
 
+###### Driver Setup for Black Magic Probe
+1. Download .inf file drivers from [blacksphere github](https://github.com/blacksphere/blackmagic/tree/master/driver)
+2. Plugin Black Magic Probe
+3. Point the installer to the folder containing blackmagic.inf
+
+__NOTE__: If using Windows 10 or Linux then two UART COM ports will be visible without requiring additional drivers
+
 ### Selecting a SoftDevice
 SoftDevices contain the BLE stack and housekeeping, and must be downloaded once before a sketch using BLE can be loaded.
 The SD consumes ~5k of Ram + some extra based on actual BLE configuration.

--- a/platform.txt
+++ b/platform.txt
@@ -129,3 +129,27 @@ tools.openocd.erase.pattern=
 tools.openocd.bootloader.params.verbose=-d2
 tools.openocd.bootloader.params.quiet=-d0
 tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -f interface/{program.protocol}.cfg -c "{program.setup_command}" -f target/{upload.target}.cfg -c "init; halt; nrf51 mass_erase; program {{{runtime.platform.path}/cores/nRF5/SDK/components/softdevice/{softdevice}/hex/{softdevice}_{upload.target}_{softdeviceversion}_softdevice.hex}} verify reset; shutdown;"
+
+#
+# blackmagic probe upload
+#
+tools.blackmagicprobe.path={runtime.tools.gcc-arm-none-eabi-5_2-2015q4.path}/bin/
+tools.blackmagicprobe.cmd=arm-none-eabi-gdb
+
+tools.blackmagicprobe.upload.speed=230400
+
+tools.blackmagicprobe.erase.params.verbose=
+tools.blackmagicprobe.erase.params.quiet=-q --batch-silent
+tools.blackmagicprobe.erase.pattern="{path}{cmd}" -quiet -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "echo \nErase finished!\n" -ex "detach" -ex "quit"
+
+tools.blackmagicprobe.upload.params.verbose=
+tools.blackmagicprobe.upload.params.quiet=-q --batch-silent
+tools.blackmagicprobe.upload.pattern="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nUpload complete!\n" -ex "quit"
+
+tools.blackmagicprobe.program.params.verbose=
+tools.blackmagicprobe.program.params.quiet=-q --batch-silent
+tools.blackmagicprobe.program.pattern="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nProgram complete!\n" -ex "quit"
+
+tools.blackmagicprobe.bootloader.params.verbose=
+tools.blackmagicprobe.bootloader.params.quiet=-q --batch-silent
+tools.blackmagicprobe.bootloader.pattern="{path}{cmd}" -quiet -cd "{runtime.platform.path}/cores/nRF5/SDK/components/softdevice/{softdevice}/hex/" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "load {softdevice}_{upload.target}_{softdeviceversion}_softdevice.hex" -ex "echo \nSoftdevice upload complete!\n" -ex "detach" -ex "quit"

--- a/programmers.txt
+++ b/programmers.txt
@@ -3,6 +3,7 @@ jlink.communication=USB
 jlink.protocol=jlink
 jlink.program.protocol=jlink
 jlink.program.tool=openocd
+jlink.bootloader.tool=openocd
 jlink.program.setup_command=transport select swd; set WORKAREASIZE 0;
 
 stlink.name=ST-Link V2
@@ -10,6 +11,7 @@ stlink.communication=USB
 stlink.protocol=stlink-v2
 stlink.program.protocol=stlink-v2
 stlink.program.tool=openocd
+stlink.bootloader.tool=openocd
 stlink.program.setup_command=transport select hla_swd; set WORKAREASIZE 0x4000;
 
 cmsisdap.name=CMSIS-DAP
@@ -17,4 +19,13 @@ cmsisdap.communication=USB
 cmsisdap.protocol=cmsis-dap
 cmsisdap.program.protocol=cmsis-dap
 cmsisdap.program.tool=openocd
+cmsisdap.bootloader.tool=openocd
 cmsisdap.program.setup_command=;
+
+bmp.name=Black Magic Probe (GDB)
+bmp.communication=USB
+bmp.protocol=
+bmp.program.protocol=
+bmp.program.tool=blackmagicprobe
+bmp.bootloader.tool=sandeepmistry:blackmagicprobe
+bmp.program.extra_params=;

--- a/programmers.txt
+++ b/programmers.txt
@@ -3,7 +3,6 @@ jlink.communication=USB
 jlink.protocol=jlink
 jlink.program.protocol=jlink
 jlink.program.tool=openocd
-jlink.bootloader.tool=openocd
 jlink.program.setup_command=transport select swd; set WORKAREASIZE 0;
 
 stlink.name=ST-Link V2
@@ -11,7 +10,6 @@ stlink.communication=USB
 stlink.protocol=stlink-v2
 stlink.program.protocol=stlink-v2
 stlink.program.tool=openocd
-stlink.bootloader.tool=openocd
 stlink.program.setup_command=transport select hla_swd; set WORKAREASIZE 0x4000;
 
 cmsisdap.name=CMSIS-DAP
@@ -19,7 +17,6 @@ cmsisdap.communication=USB
 cmsisdap.protocol=cmsis-dap
 cmsisdap.program.protocol=cmsis-dap
 cmsisdap.program.tool=openocd
-cmsisdap.bootloader.tool=openocd
 cmsisdap.program.setup_command=;
 
 blackmagicprobe.name=Black Magic Probe (GDB)

--- a/programmers.txt
+++ b/programmers.txt
@@ -22,10 +22,10 @@ cmsisdap.program.tool=openocd
 cmsisdap.bootloader.tool=openocd
 cmsisdap.program.setup_command=;
 
-bmp.name=Black Magic Probe (GDB)
-bmp.communication=USB
-bmp.protocol=
-bmp.program.protocol=
-bmp.program.tool=blackmagicprobe
-bmp.bootloader.tool=sandeepmistry:blackmagicprobe
-bmp.program.extra_params=;
+blackmagicprobe.name=Black Magic Probe (GDB)
+blackmagicprobe.communication=USB
+blackmagicprobe.protocol=
+blackmagicprobe.program.protocol=
+blackmagicprobe.program.tool=blackmagicprobe
+blackmagicprobe.bootloader.tool=sandeepmistry:blackmagicprobe
+blackmagicprobe.program.extra_params=;


### PR DESCRIPTION
In support of 'issue' #183 - Add Black Magic Probe (BMP) upload method  …
This is basically a merge of work done by @rogerclarkmelbourne in arduino-nRF5-customised, with the addition of bootloader uploading as per @sandeepmistry openocd reference in platform.txt
Note: This incorporates changes based off feedback from @sandeepmistry, @dmikhalsky, @dlabun
* README.md - BMP driver installation details
* platform.txt - BMP tool setup
* programmers.txt - Add BMP as a programmer option