### PR TITLE
Taida Century NRF52 minidev board variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Does not require a custom bootloader on the device.
  * [Plain nRF52 MCU](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52832)
  * [Nordic Semiconductor nRF52 DK](https://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF52-DK)
    * For boards prior to ```2016.9``` (see sticker), the lastest JLink bootloader is required to upload sketches. To upgrade, press the boot/reset button while powering on the board and copy over the latest [bootloader](https://www.nordicsemi.com/eng/nordic/Products/nRF52-DK/nRF5x-OB-JLink-IF/52275).
- * [Shenzhen Taida Century Technology nRF52 low cost development board](https://www.aliexpress.com/item/NRF52832-high-cost-development-board-gold-core-board/32725601299.html)
+ * [Shenzhen Taida Century Technology nRF52 low cost development board](https://micooke.github.io/nRF52832_TaidaCentury_GoldCore)
  * [RedBear Blend 2](https://github.com/redbear/nRF5x#blend-2)
  * [RedBear Nano 2](https://github.com/redbear/nRF5x#ble-nano-2)
  * [Bluey](https://github.com/electronut/ElectronutLabs-bluey)

--- a/boards.txt
+++ b/boards.txt
@@ -50,7 +50,7 @@ Generic_nRF52832.menu.softdevice.s132=S132
 Generic_nRF52832.menu.softdevice.s132.softdevice=s132
 Generic_nRF52832.menu.softdevice.s132.softdeviceversion=2.0.1
 Generic_nRF52832.menu.softdevice.s132.upload.maximum_size=409600
-Generic_nRF52832.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+Generic_nRF52832.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF52_S132
 Generic_nRF52832.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
 
 Generic_nRF52832.menu.lfclk.lfxo=Crystal Oscillator
@@ -88,7 +88,7 @@ bluey.menu.softdevice.s132=S132
 bluey.menu.softdevice.s132.softdevice=s132
 bluey.menu.softdevice.s132.softdeviceversion=2.0.1
 bluey.menu.softdevice.s132.upload.maximum_size=409600
-bluey.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+bluey.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF52_S132
 bluey.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
 
 bluey.menu.lfclk.lfxo=Crystal Oscillator
@@ -136,7 +136,7 @@ Blend2.menu.softdevice.s132=S132
 Blend2.menu.softdevice.s132.softdevice=s132
 Blend2.menu.softdevice.s132.softdeviceversion=2.0.1
 Blend2.menu.softdevice.s132.upload.maximum_size=409600
-Blend2.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+Blend2.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF52_S132
 Blend2.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
 
 
@@ -176,7 +176,7 @@ BLENano2.menu.softdevice.s132=S132
 BLENano2.menu.softdevice.s132.softdevice=s132
 BLENano2.menu.softdevice.s132.softdeviceversion=2.0.1
 BLENano2.menu.softdevice.s132.upload.maximum_size=409600
-BLENano2.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+BLENano2.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF52_S132
 BLENano2.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
 
 
@@ -216,7 +216,7 @@ nRF52DK.menu.softdevice.s132=S132
 nRF52DK.menu.softdevice.s132.softdevice=s132
 nRF52DK.menu.softdevice.s132.softdeviceversion=2.0.1
 nRF52DK.menu.softdevice.s132.upload.maximum_size=409600
-nRF52DK.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+nRF52DK.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF52_S132
 nRF52DK.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
 
 
@@ -248,8 +248,17 @@ STCT_nRF52_minidev.menu.softdevice.s132=S132
 STCT_nRF52_minidev.menu.softdevice.s132.softdevice=s132
 STCT_nRF52_minidev.menu.softdevice.s132.softdeviceversion=2.0.1
 STCT_nRF52_minidev.menu.softdevice.s132.upload.maximum_size=409600
-STCT_nRF52_minidev.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+STCT_nRF52_minidev.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF52_S132
 STCT_nRF52_minidev.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
+
+STCT_nRF52_minidev.menu.board_variant.none=None
+STCT_nRF52_minidev.menu.board_variant.rgz.build.lfclk_flags=-DUSE_LFXO -DSTCT_NRF52_minidev
+
+STCT_nRF52_minidev.menu.board_variant.rgz=RGZ
+STCT_nRF52_minidev.menu.board_variant.rgz.build.lfclk_flags=-DUSE_LFXO -DSTCT_NRF52_minidev_RGZ
+
+STCT_nRF52_minidev.menu.board_variant.rsm=RSM
+STCT_nRF52_minidev.menu.board_variant.rsm.build.lfclk_flags=-DUSE_LFXO -DSTCT_NRF52_minidev_RSM
 
 
 # nRF51 variants

--- a/variants/Taida_Century_nRF52_minidev/variant.h
+++ b/variants/Taida_Century_nRF52_minidev/variant.h
@@ -1,4 +1,5 @@
 /*
+/*
   Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
   Copyright (c) 2016 Sandeep Mistry All right reserved.
   Copyright (c) 2016 Frank Holtz. All right reserved.

--- a/variants/Taida_Century_nRF52_minidev/variant.h
+++ b/variants/Taida_Century_nRF52_minidev/variant.h
@@ -16,11 +16,15 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _VARIANT_NRF52_MINIDEV_
-#define _VARIANT_NRF52_MINIDEV_
+#ifndef _VARIANT_STCT_NRF52_minidev_
+#define _VARIANT_STCT_NRF52_minidev_
 
 /** Master clock frequency */
+#ifdef NRF52
 #define VARIANT_MCK       (64000000ul)
+#else
+#define VARIANT_MCK       (16000000ul)
+#endif
 
 /*----------------------------------------------------------------------------
  *        Headers
@@ -40,66 +44,85 @@ extern "C"
 #define NUM_ANALOG_OUTPUTS   (0u)
 
 // LEDs
-#define PIN_LED1                (5)
-#define PIN_LED2                (6)
+#define PIN_LED1                (5u)
+#define PIN_LED2                (6u)
 #define LED_BUILTIN             PIN_LED1
 
 // Buttons
 // KEY
-#define PIN_BUTTON1             (9)
+#define PIN_BUTTON1             (9u)
 // Reset -> read nordic documentation for disabling reset function
-#define PIN_BUTTON2             (31)
+#define PIN_BUTTON2             (31u)
 
 /*
  * Analog pins
  */
-#define PIN_A0               (25)
-#define PIN_A1               (26)
-#define PIN_A2               (27)
-#define PIN_A3               (28)
-#define PIN_A4               (29)
-#define PIN_A5               (30)
+#define PIN_A0               (25u)
+#define PIN_A1               (26u)
+#define PIN_A2               (27u)
+#define PIN_A3               (28u)
+#define PIN_A4               (29u)
+#define PIN_A5               (30u)
 
-static const uint8_t A0  = PIN_A0 ;
-static const uint8_t A1  = PIN_A1 ;
-static const uint8_t A2  = PIN_A2 ;
-static const uint8_t A3  = PIN_A3 ;
-static const uint8_t A4  = PIN_A4 ;
-static const uint8_t A5  = PIN_A5 ;
+static const uint8_t A0  = PIN_A0;
+static const uint8_t A1  = PIN_A1;
+static const uint8_t A2  = PIN_A2;
+static const uint8_t A3  = PIN_A3;
+static const uint8_t A4  = PIN_A4;
+static const uint8_t A5  = PIN_A5;
+#ifdef NRF52
 #define ADC_RESOLUTION    14
+#else
+#define ADC_RESOLUTION    10
+#endif
 
 // Other pins
 #define PIN_AREF           (24)
 static const uint8_t AREF = PIN_AREF;
 
 /*
- * Serial interfaces
- */
-// Serial
-#define PIN_SERIAL_RX       (18)
-#define PIN_SERIAL_TX       (19)
-
-/*
  * SPI Interfaces
  */
 #define SPI_INTERFACES_COUNT 1
 
-#define PIN_SPI_MISO         (21)
-#define PIN_SPI_MOSI         (22)
-#define PIN_SPI_SCK          (23)
+#define PIN_SPI_MISO         (21u)
+#define PIN_SPI_MOSI         (22u)
+#define PIN_SPI_SCK          (23u)
 
-static const uint8_t SS   = 20 ;
-static const uint8_t MOSI = PIN_SPI_MOSI ;
-static const uint8_t MISO = PIN_SPI_MISO ;
-static const uint8_t SCK  = PIN_SPI_SCK ;
+static const uint8_t SS   = 20u;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK  = PIN_SPI_SCK;
+
+/*
+ * Serial interfaces
+ */
+// Serial
+#ifdef STCT_NRF52_minidev_RGZ  // J11 - J12 soldered (RGZ)
+#define PIN_SERIAL_RX       (2u)
+#define PIN_SERIAL_TX       (3u)
+#elif defined (STCT_NRF52_minidev_RSM)  // J15 - J16 soldered (RSM)
+#define PIN_SERIAL_RX       (1u)
+#define PIN_SERIAL_TX       (2u)
+#else // original configuration
+#define PIN_SERIAL_RX       (18u)
+#define PIN_SERIAL_TX       (19u)
+#endif
 
 /*
  * Wire Interfaces
  */
 #define WIRE_INTERFACES_COUNT 1
-
+#ifdef STCT_NRF52_minidev_RGZ
+#define PIN_WIRE_SDA         (7u)
+#define PIN_WIRE_SCL         (8u)
+#elif defined (STCT_NRF52_minidev_RSM)
+#define PIN_WIRE_SDA         (7u)
+#define PIN_WIRE_SCL         (8u)
+#else // original configuration
 #define PIN_WIRE_SDA         (2u)
 #define PIN_WIRE_SCL         (3u)
+#endif
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
@@ -107,9 +130,5 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 #ifdef __cplusplus
 }
 #endif
-
-/*----------------------------------------------------------------------------
- *        Arduino objects - C++ only
- *----------------------------------------------------------------------------*/
 
 #endif


### PR DESCRIPTION
Regarding issue #200 - add pin mapping and associated documentation for RGZ and RSM variants

Also fix incorrect defines in boards.txt -DNRF51_S132 => -DNRF52_S132