### PR TITLE
In support of issue #98 (SoftwareSerial not working)

### DIFF
--- a/cores/nRF5/Arduino.h
+++ b/cores/nRF5/Arduino.h
@@ -29,11 +29,11 @@ extern "C"{
 #define clockCyclesToMicroseconds(a) ( ((a) * 1000L) / (SystemCoreClock / 1000L) )
 #define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
 
-void yield( void ) ;
+void yield( void );
 
 /* sketch */
-void setup( void ) ;
-void loop( void ) ;
+void setup( void );
+void loop( void );
 
 #include "WVariant.h"
 
@@ -92,12 +92,12 @@ void loop( void ) ;
 
 #define bit(b) (1UL << (b))
 
-#define digitalPinToPort(P)        ( &(NRF_GPIO[P]) )
+#define digitalPinToPort(P)        ( NRF_GPIO ) // NRF_P0 = P0.00 - P0.31, NRF_P1 = P1.00 - P1.15 (e.g. nRF52840)
 #define digitalPinToBitMask(P)     ( 1 << g_ADigitalPinMap[P] )
 //#define analogInPinToBit(P)        ( )
-#define portOutputRegister(port)   ( &(port->OUTSET) )
+#define portOutputRegister(port)   ( &(port->OUT) )
 #define portInputRegister(port)    ( &(port->IN) )
-#define portModeRegister(port)     ( &(port->DIRSET) )
+#define portModeRegister(port)     ( &(port->DIR) )
 #define digitalPinHasPWM(P)        ( true )
 
 /*

--- a/cores/nRF5/WInterrupts.h
+++ b/cores/nRF5/WInterrupts.h
@@ -40,7 +40,7 @@ typedef void (*voidFuncPtr)(void);
  * \brief Specifies a named Interrupt Service Routine (ISR) to call when an interrupt occurs.
  *        Replaces any previous function that was attached to the interrupt.
  */
-void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode);
+int attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode);
 
 /*
  * \brief Turns off the given interrupt.


### PR DESCRIPTION
This PR does not currently include a SoftwareSerial library, but it is compatible with the arduino-org and adafruit nrf52 SoftwareSerial libraries.

### Arduino.h
* fix errors in #defines for digitalPinToPort, portOutputRegister, portModeRegister
### WInterrupts
* change attachInterrupt define to return the interrupt mask
* callbacksInt, channelMap now uses an initialiser list instead of memset
* GPIOTE_IRQn priority dropped from 1 to 3 (same as Uart priority)
* LOW and HIGH modes added to attachInterrupt for compatibility, which are the same as FALLING and RISING respectively as GPIOTE does not support HIGH and LOW modes
* To free up clock cycles between GPIOTE interrupts GPIOTE_IRQHandler now searches for the first GPIOTE event and breaks to execute, rather than staying in the interrupt and executing each GPIOTE callback that has triggered an interrupt.