### PR TITLE
disable DMA I2C on BLE Nano 2

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -31,16 +31,20 @@
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
+#if defined(NRF52) && !defined(ARDUINO_RB_BLE_NANO_2)
+#define USE_DMA_TWI 1
+#endif
+
 class TwoWire : public Stream
 {
   public:
-#ifdef NRF52
+#ifdef USE_DMA_TWI
     TwoWire(NRF_TWIM_Type * p_twim, NRF_TWIS_Type * p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
 #else
     TwoWire(NRF_TWI_Type * p_twi, uint8_t pinSDA, uint8_t pinSCL);
 #endif
     void begin();
-#ifdef NRF52
+#ifdef USE_DMA_TWI
     void begin(uint8_t);
 #endif
     void end();
@@ -60,7 +64,7 @@ class TwoWire : public Stream
     virtual int read(void);
     virtual int peek(void);
     virtual void flush(void);
-#ifdef NRF52
+#ifdef USE_DMA_TWI
     void onReceive(void(*)(int));
     void onRequest(void(*)(void));
     void onService(void);
@@ -69,7 +73,7 @@ class TwoWire : public Stream
     using Print::write;
 
   private:
-#ifdef NRF52
+#ifdef USE_DMA_TWI
     NRF_TWIM_Type * _p_twim;
     NRF_TWIS_Type * _p_twis;
 #else

--- a/libraries/Wire/Wire_nRF51.cpp
+++ b/libraries/Wire/Wire_nRF51.cpp
@@ -18,7 +18,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifdef NRF51
+#include "Wire.h"
+
+#ifndef USE_DMA_TWI
 
 extern "C" {
 #include <string.h>
@@ -27,8 +29,6 @@ extern "C" {
 
 #include <Arduino.h>
 #include <wiring_private.h>
-
-#include "Wire.h"
 
 TwoWire::TwoWire(NRF_TWI_Type * p_twi, uint8_t pinSDA, uint8_t pinSCL)
 {

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -18,7 +18,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifdef NRF52
+#include "Wire.h"
+
+#ifdef USE_DMA_TWI
 
 extern "C" {
 #include <string.h>
@@ -26,8 +28,6 @@ extern "C" {
 
 #include <Arduino.h>
 #include <wiring_private.h>
-
-#include "Wire.h"
 
 TwoWire::TwoWire(NRF_TWIM_Type * p_twim, NRF_TWIS_Type * p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL)
 {


### PR DESCRIPTION
This will at least get I2C working on the RedBear BLE Nano 2.

I don't have any different boards for which this is a problem, so I'm assuming Wire_nRF52 is working for everything else except the Nano 2.