### PR TITLE
Enhancement : Add GPIO pin mapping functions

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -20,6 +20,7 @@ menu.softdevice=Softdevice
 menu.version=Version
 menu.lfclk=Low Frequency Clock
 menu.board_variant=Board Variant
+menu.gpio_config=GPIO Configuration
 
 # nRF52832 variants
 ###################
@@ -60,6 +61,14 @@ Generic_nRF52832.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
 Generic_nRF52832.menu.lfclk.lfsynt=Synthesized
 Generic_nRF52832.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT
 
+Generic_nRF52832.menu.gpio_config.default=No Pin Reset, NFC pins as Antenna (default)
+Generic_nRF52832.menu.gpio_config.default.build.gpio_flags=
+Generic_nRF52832.menu.gpio_config.PinResetNFCAntenna=Pin Reset, NFC pins as Antenna
+Generic_nRF52832.menu.gpio_config.PinResetNFCAntenna.build.gpio_flags=-DCONFIG_GPIO_AS_PINRESET
+Generic_nRF52832.menu.gpio_config.NoPinResetNFCGPIO=No Pin Reset, NFC pins as GPIO
+Generic_nRF52832.menu.gpio_config.NoPinResetNFCGPIO.build.gpio_flags=-DCONFIG_NFCT_PINS_AS_GPIOS
+Generic_nRF52832.menu.gpio_config.PinResetNFCGPIO=Pin Reset, NFC pins as GPIO
+Generic_nRF52832.menu.gpio_config.PinResetNFCGPIO.build.gpio_flags=-DCONFIG_GPIO_AS_PINRESET -DCONFIG_NFCT_PINS_AS_GPIOS
 
 
 bluey.name=Electronut labs bluey

--- a/platform.txt
+++ b/platform.txt
@@ -51,6 +51,7 @@ compiler.define=-DARDUINO=
 # this can be overriden in boards.txt
 build.extra_flags=
 build.lfclk_flags=
+build.gpio_flags=
 
 nrf.sdk.path={build.core.path}/SDK
 
@@ -70,13 +71,13 @@ compiler.elf2hex.extra_flags=
 # ----------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {compiler.nrf.flags} {build.lfclk_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {compiler.nrf.flags} {build.lfclk_flags} {build.gpio_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {compiler.nrf.flags} {build.lfclk_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {compiler.nrf.flags} {build.lfclk_flags} {build.gpio_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {build.lfclk_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {build.lfclk_flags} {build.gpio_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"


### PR DESCRIPTION
GPIO pin mapping options added to platform.txt and GPIO pin mapping options added example Generic_nRF52832 example:
* default=No Pin Reset, NFC pins as Antenna (default)
* PinResetNFCAntenna=Pin Reset, NFC pins as Antenna
* NoPinResetNFCGPIO=No Pin Reset, NFC pins as GPIO
* PinResetNFCGPIO=Pin Reset, NFC pins as GPIO

In support of issue #206 : nRF52 - use NFC pins as GPIO and as an alternative to PR #91 : Support standard reset button as default. 