### PR TITLE
Fix I2C lock-up when endTransmission() is called with empty txBuffer

### DIFF
--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -214,7 +214,9 @@ uint8_t TwoWire::endTransmission(bool stopBit)
   while(!_p_twim->EVENTS_TXSTARTED && !_p_twim->EVENTS_ERROR);
   _p_twim->EVENTS_TXSTARTED = 0x0UL;
 
-  while(!_p_twim->EVENTS_LASTTX && !_p_twim->EVENTS_ERROR);
+  if (txBuffer.available()) {
+    while(!_p_twim->EVENTS_LASTTX && !_p_twim->EVENTS_ERROR);
+  }
   _p_twim->EVENTS_LASTTX = 0x0UL;
 
   if (stopBit || _p_twim->EVENTS_ERROR)


### PR DESCRIPTION
This is fixing the lock-ups that are described in #108, #207, and #199. The problem (at least in the case of the I2C scanner that I had to deal with) is related to an empty tx buffer, so the LASTTX event never occurres, resulting into an endless loop.