### PR TITLE
Custom I2C/SPI/UART pins for generic variants

### DIFF
--- a/cores/nRF5/Uart.cpp
+++ b/cores/nRF5/Uart.cpp
@@ -41,6 +41,22 @@ Uart::Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pi
   uc_hwFlow = 1;
 }
 
+#ifdef ARDUINO_GENERIC
+void Uart::setPins(uint8_t _pinRX, uint8_t _pinTX)
+{
+  uc_pinRX = g_ADigitalPinMap[_pinRX];
+  uc_pinTX = g_ADigitalPinMap[_pinTX];
+}
+
+void Uart::setPins(uint8_t _pinRX, uint8_t _pinTX, uint8_t _pinCTS, uint8_t _pinRTS)
+{
+  uc_pinRX = g_ADigitalPinMap[_pinRX];
+  uc_pinTX = g_ADigitalPinMap[_pinTX];
+  uc_pinCTS = g_ADigitalPinMap[_pinCTS];
+  uc_pinRTS = g_ADigitalPinMap[_pinRTS];
+}
+#endif // ARDUINO_GENERIC
+
 void Uart::begin(unsigned long baudrate)
 {
   begin(baudrate, (uint8_t)SERIAL_8N1);

--- a/cores/nRF5/Uart.h
+++ b/cores/nRF5/Uart.h
@@ -31,6 +31,10 @@ class Uart : public HardwareSerial
   public:
     Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pinTX);
     Uart(NRF_UART_Type *_nrfUart, IRQn_Type _IRQn, uint8_t _pinRX, uint8_t _pinTX, uint8_t _pinCTS, uint8_t _pinRTS );
+#ifdef ARDUINO_GENERIC
+    void setPins(uint8_t _pinRX, uint8_t _pinTX);
+    void setPins(uint8_t _pinRX, uint8_t _pinTX, uint8_t _pinCTS, uint8_t _pinRTS);
+#endif // ARDUINO_GENERIC
     void begin(unsigned long baudRate);
     void begin(unsigned long baudrate, uint16_t config);
     void end();

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -44,6 +44,15 @@ SPIClass::SPIClass(NRF_SPI_Type *p_spi, uint8_t uc_pinMISO, uint8_t uc_pinSCK, u
   _bitOrder = SPI_CONFIG_ORDER_MsbFirst;
 }
 
+#ifdef ARDUINO_GENERIC
+void SPIClass::setPins(uint8_t uc_pinMISO, uint8_t uc_pinSCK, uint8_t uc_pinMOSI)
+{
+  _uc_pinMiso = g_ADigitalPinMap[uc_pinMISO];
+  _uc_pinSCK = g_ADigitalPinMap[uc_pinSCK];
+  _uc_pinMosi = g_ADigitalPinMap[uc_pinMOSI];
+}
+#endif // ARDUINO_GENERIC
+
 void SPIClass::begin()
 {
   init();

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -100,6 +100,9 @@ class SPIClass {
   void attachInterrupt();
   void detachInterrupt();
 
+#ifdef ARDUINO_GENERIC
+  void setPins(uint8_t uc_pinMISO, uint8_t uc_pinSCK, uint8_t uc_pinMOSI);
+#endif // ARDUINO_GENERIC
   void begin();
   void end();
 

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -39,6 +39,9 @@ class TwoWire : public Stream
 #else
     TwoWire(NRF_TWI_Type * p_twi, uint8_t pinSDA, uint8_t pinSCL);
 #endif
+#ifdef ARDUINO_GENERIC
+    void setPins(uint8_t pinSDA, uint8_t pinSCL);
+#endif // ARDUINO_GENERIC
     void begin();
 #ifdef NRF52
     void begin(uint8_t);

--- a/libraries/Wire/Wire_nRF51.cpp
+++ b/libraries/Wire/Wire_nRF51.cpp
@@ -39,6 +39,14 @@ TwoWire::TwoWire(NRF_TWI_Type * p_twi, uint8_t pinSDA, uint8_t pinSCL)
   this->suspended = false;
 }
 
+#ifdef ARDUINO_GENERIC
+void TwoWire::setPins(uint8_t pinSDA, uint8_t pinSCL)
+{
+  this->_uc_pinSDA = g_ADigitalPinMap[pinSDA];
+  this->_uc_pinSCL = g_ADigitalPinMap[pinSCL];
+}
+#endif // ARDUINO_GENERIC
+
 void TwoWire::begin(void) {
   //Master Mode
   master = true;

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -39,6 +39,14 @@ TwoWire::TwoWire(NRF_TWIM_Type * p_twim, NRF_TWIS_Type * p_twis, IRQn_Type IRQn,
   transmissionBegun = false;
 }
 
+#ifdef ARDUINO_GENERIC
+void TwoWire::setPins(uint8_t pinSDA, uint8_t pinSCL)
+{
+  this->_uc_pinSDA = g_ADigitalPinMap[pinSDA];
+  this->_uc_pinSCL = g_ADigitalPinMap[pinSCL];
+}
+#endif // ARDUINO_GENERIC
+
 void TwoWire::begin(void) {
   //Master Mode
   master = true;


### PR DESCRIPTION
Hi again @sandeepmistry & @dlabun!

As said in the issue #213, this Generic variant that you offer here is a really great feature, but the default Wire/Serial/SPI objects are initialized with default pins that are forced.
It makes sense for most boards, but maybe not for the generic variants as these forced pins could be unavailable.

The 3 commits of this pull requests implement a setPins(...) method for the 3 objects aforementioned (Wire/Serial/SPI), calling it before its respective begin() would solve the problem.

Let me know if there's anything I can do to improve these commits...
Cedric ;)
