### PR TITLE
Add -D{board.variant} to build.extra_flags of PCA1000X softdevices

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -465,14 +465,14 @@ PCA1000X.menu.softdevice.s110=S110
 PCA1000X.menu.softdevice.s110.softdevice=s110
 PCA1000X.menu.softdevice.s110.softdeviceversion=8.0.0
 PCA1000X.menu.softdevice.s110.upload.maximum_size=151552
-PCA1000X.menu.softdevice.s110.build.extra_flags=-DNRF51 -DS110 -DNRF51_S110
+PCA1000X.menu.softdevice.s110.build.extra_flags=-DNRF51 -D{board.variant} -DS110 -DNRF51_S110
 PCA1000X.menu.softdevice.s110.build.ldscript=armgcc_s110_nrf51822_xxaa.ld
 
 PCA1000X.menu.softdevice.s130=S130
 PCA1000X.menu.softdevice.s130.softdevice=s130
 PCA1000X.menu.softdevice.s130.softdeviceversion=2.0.1
 PCA1000X.menu.softdevice.s130.upload.maximum_size=151552
-PCA1000X.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
+PCA1000X.menu.softdevice.s130.build.extra_flags=-DNRF51 -D{board.variant} -DS130 -DNRF51_S130
 PCA1000X.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxaa.ld
 
 PCA1000X.menu.lfclk.lfxo=Crystal Oscillator


### PR DESCRIPTION
The _build.extra_flags_ for PCA1000X boards include `-D{board.variant}`:
`PCA1000X.build.extra_flags=-DNRF51 -D{board.variant}`
However, this extra flag is currently not also part of the _build.extra_flags_ of the PCA1000X softdevices:
```
PCA1000X.menu.softdevice.s110.build.extra_flags=-DNRF51 -DS110 -DNRF51_S110
[...]
PCA1000X.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
```
Because of this, `-D{board.variant}` will actually only be used on PCA1000X boards when selecting softdevice "none".
On PCA1000X boards that require hardware flow control for UART communication (like the PCA10000 and PCA10001), this for example leads to the strange effect that serial port communication currently only works when selecting softdevice "none".