### PR TITLE
Add PCA1000X variant PCA10001

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   - buildExampleSketch sandeepmistry:nRF5:OSHChip 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:STCT_nRF52_minidev 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:PCA1000X:board_variant=pca10000 01.Basics Blink
+  - buildExampleSketch sandeepmistry:nRF5:PCA1000X:board_variant=pca10001 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:PCA1000X:board_variant=nrf6310 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:nRF51Dongle:version=1_1_0 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:Blend2 01.Basics Blink

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Does not require a custom bootloader on the device.
  * [Bluz DK](http://bluz.io)
  * Nordic Semiconductor  [nRF51822 Development Kit](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822-Development-Kit) + [nRF51422 Development Kit](https://www.nordicsemi.com/eng/Products/ANT/nRF51422-Development-Kit)
   * PCA10000
+  * PCA10001
   * PCA10001, PCA10002, PCA10003, PCA10004 via nRF6310(nRFgo)
  * [Nordic Semiconductor NRF51 Smart Beacon Kit](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822-Bluetooth-Smart-Beacon-Kit)
  * [Nordic Semiconductor NRF51 Dongle](http://www.nordicsemi.com/eng/Products/nRF51-Dongle)

--- a/boards.txt
+++ b/boards.txt
@@ -454,6 +454,8 @@ PCA1000X.upload.setup_command=transport select swd; set WORKAREASIZE 0;
 
 PCA1000X.menu.board_variant.pca10000=PCA10000
 PCA1000X.menu.board_variant.pca10000.board.variant=PCA10000
+PCA1000X.menu.board_variant.pca10001=PCA10001
+PCA1000X.menu.board_variant.pca10001.board.variant=PCA10001
 PCA1000X.menu.board_variant.nrf6310=PCA1000X (via nRF6310)
 PCA1000X.menu.board_variant.nrf6310.board.variant=NRF6310
 

--- a/variants/PCA1000X/variant.h
+++ b/variants/PCA1000X/variant.h
@@ -34,7 +34,54 @@ extern "C"
 #endif // __cplusplus
 
 // Number of pins defined in PinDescription array
-#ifndef PCA10000
+#ifdef PCA10000
+  /* PCA10000
+   * *********/
+
+  #define PINS_COUNT           (7u)
+  #define NUM_DIGITAL_PINS     (7u)
+  #define NUM_ANALOG_INPUTS    (0u)
+  #define NUM_ANALOG_OUTPUTS   (0u)
+
+  // LEDs
+  #define PIN_LED1                (4)
+  #define PIN_LED2                (5)
+  #define PIN_LED3                (6)
+  #define LED_BUILTIN             PIN_LED1
+
+  /*
+   * Serial interfaces
+   */
+  #define PIN_SERIAL_RX       (3)
+  #define PIN_SERIAL_CTS      (2)
+  #define PIN_SERIAL_TX       (1)
+  #define PIN_SERIAL_RTS      (0)
+#elif defined(PCA10001)
+  /* PCA10001
+   * *********/
+
+  #define PINS_COUNT           (32u)
+  #define NUM_DIGITAL_PINS     (32u)
+  #define NUM_ANALOG_INPUTS    (0u)
+  #define NUM_ANALOG_OUTPUTS   (0u)
+
+  // LEDs
+  #define PIN_LED0                (18)
+  #define PIN_LED1                (19)
+  #define LED_BUILTIN             PIN_LED0
+
+  // Buttons
+  #define PIN_BUTTON0             (16)
+  #define PIN_BUTTON1             (17)
+
+  /*
+   * Serial interfaces
+   */
+  #define PIN_SERIAL_RX       (11)
+  #define PIN_SERIAL_CTS      (10)
+  #define PIN_SERIAL_TX       (9)
+  #define PIN_SERIAL_RTS      (8)
+#else
   /* PCA1000[1,2,3,4] on nRF6310
    * ****************************/
   #define PINS_COUNT           (32u)
@@ -113,28 +160,6 @@ extern "C"
   static const uint8_t SDA = PIN_WIRE_SDA;
   static const uint8_t SCL = PIN_WIRE_SCL;
 
-#else
-  /* PCA10000
-   * *********/
-
-  #define PINS_COUNT           (7u)
-  #define NUM_DIGITAL_PINS     (7u)
-  #define NUM_ANALOG_INPUTS    (0u)
-  #define NUM_ANALOG_OUTPUTS   (0u)
-
-  // LEDs
-  #define PIN_LED1                (4)
-  #define PIN_LED2                (5)
-  #define PIN_LED3                (6)
-  #define LED_BUILTIN             PIN_LED1
-
-  /*
-   * Serial interfaces
-   */
-  #define PIN_SERIAL_RX       (3)
-  #define PIN_SERIAL_CTS      (2)
-  #define PIN_SERIAL_TX       (1)
-  #define PIN_SERIAL_RTS      (0)
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR adds a PCA1000X board variant called PCA10001, for the PCA10001 development board.