### PR TITLE
Remove '\\.\', closes #245

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -140,16 +140,16 @@ tools.blackmagicprobe.upload.speed=230400
 
 tools.blackmagicprobe.erase.params.verbose=
 tools.blackmagicprobe.erase.params.quiet=-q --batch-silent
-tools.blackmagicprobe.erase.pattern="{path}{cmd}" -quiet -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "echo \nErase finished!\n" -ex "detach" -ex "quit"
+tools.blackmagicprobe.erase.pattern="{path}{cmd}" -quiet -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "echo \nErase finished!\n" -ex "detach" -ex "quit"
 
 tools.blackmagicprobe.upload.params.verbose=
 tools.blackmagicprobe.upload.params.quiet=-q --batch-silent
-tools.blackmagicprobe.upload.pattern="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nUpload complete!\n" -ex "quit"
+tools.blackmagicprobe.upload.pattern="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nUpload complete!\n" -ex "quit"
 
 tools.blackmagicprobe.program.params.verbose=
 tools.blackmagicprobe.program.params.quiet=-q --batch-silent
-tools.blackmagicprobe.program.pattern="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nProgram complete!\n" -ex "quit"
+tools.blackmagicprobe.program.pattern="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nProgram complete!\n" -ex "quit"
 
 tools.blackmagicprobe.bootloader.params.verbose=
 tools.blackmagicprobe.bootloader.params.quiet=-q --batch-silent
-tools.blackmagicprobe.bootloader.pattern="{path}{cmd}" -quiet -cd "{runtime.platform.path}/cores/nRF5/SDK/components/softdevice/{softdevice}/hex/" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "load {softdevice}_{upload.target}_{softdeviceversion}_softdevice.hex" -ex "echo \nSoftdevice upload complete!\n" -ex "detach" -ex "quit"
+tools.blackmagicprobe.bootloader.pattern="{path}{cmd}" -quiet -cd "{runtime.platform.path}/cores/nRF5/SDK/components/softdevice/{softdevice}/hex/" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "load {softdevice}_{upload.target}_{softdeviceversion}_softdevice.hex" -ex "echo \nSoftdevice upload complete!\n" -ex "detach" -ex "quit"

--- a/platform.txt
+++ b/platform.txt
@@ -141,15 +141,19 @@ tools.blackmagicprobe.upload.speed=230400
 tools.blackmagicprobe.erase.params.verbose=
 tools.blackmagicprobe.erase.params.quiet=-q --batch-silent
 tools.blackmagicprobe.erase.pattern="{path}{cmd}" -quiet -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "echo \nErase finished!\n" -ex "detach" -ex "quit"
+tools.blackmagicprobe.erase.pattern.windows="{path}{cmd}" -quiet -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "echo \nErase finished!\n" -ex "detach" -ex "quit"
 
 tools.blackmagicprobe.upload.params.verbose=
 tools.blackmagicprobe.upload.params.quiet=-q --batch-silent
 tools.blackmagicprobe.upload.pattern="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nUpload complete!\n" -ex "quit"
+tools.blackmagicprobe.upload.pattern.windows="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nUpload complete!\n" -ex "quit"
 
 tools.blackmagicprobe.program.params.verbose=
 tools.blackmagicprobe.program.params.quiet=-q --batch-silent
 tools.blackmagicprobe.program.pattern="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nProgram complete!\n" -ex "quit"
+tools.blackmagicprobe.program.pattern.windows="{path}{cmd}" -quiet -cd "{build.path}" -b {upload.speed} -l 10 -ex "set debug remote 0" -ex "set target-async off" -ex "set remotetimeout 10" -ex "set mem inaccessible-by-default off" -ex "set confirm off" -ex "set height 0" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "file {build.project_name}.elf" -ex "load" -ex "tbreak main" -ex "run" -ex "echo \nProgram complete!\n" -ex "quit"
 
 tools.blackmagicprobe.bootloader.params.verbose=
 tools.blackmagicprobe.bootloader.params.quiet=-q --batch-silent
 tools.blackmagicprobe.bootloader.pattern="{path}{cmd}" -quiet -cd "{runtime.platform.path}/cores/nRF5/SDK/components/softdevice/{softdevice}/hex/" -ex "target extended-remote {serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "load {softdevice}_{upload.target}_{softdeviceversion}_softdevice.hex" -ex "echo \nSoftdevice upload complete!\n" -ex "detach" -ex "quit"
+tools.blackmagicprobe.bootloader.pattern.windows="{path}{cmd}" -quiet -cd "{runtime.platform.path}/cores/nRF5/SDK/components/softdevice/{softdevice}/hex/" -ex "target extended-remote \\.\{serial.port}" -ex "monitor swdp_scan" -ex "attach 1" -ex "monitor erase mass" -ex "load {softdevice}_{upload.target}_{softdeviceversion}_softdevice.hex" -ex "echo \nSoftdevice upload complete!\n" -ex "detach" -ex "quit"


### PR DESCRIPTION
This fixes the `\\.\/dev/ttyACM0: No such file or directory` error on Linux.