### PR TITLE
Add support for Raytac MDBT40 module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - buildExampleSketch sandeepmistry:nRF5:PCA1000X:board_variant=pca10000 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:PCA1000X:board_variant=pca10001 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:PCA1000X:board_variant=nrf6310 01.Basics Blink
+  - buildExampleSketch sandeepmistry:nRF5:Raytac_MDBT40 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:nRF51Dongle:version=1_1_0 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:Blend2 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:BLENano2 01.Basics Blink

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Become a sponsor and get your logo on our README on Github with a link to your s
  * [Nordic Semiconductor NRF51 Smart Beacon Kit](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822-Bluetooth-Smart-Beacon-Kit)
  * [Nordic Semiconductor NRF51 Dongle](http://www.nordicsemi.com/eng/Products/nRF51-Dongle)
  * [OSHChip](http://www.oshchip.org/)
+ * [Raytac MDBT40](http://www.raytac.com/product/ins.php?index_id=63)
  * [RedBearLab BLE Nano](http://redbearlab.com/blenano/)
  * [RedBearLab nRF51822](http://redbearlab.com/redbearlab-nrf51822/)
  * [Waveshare BLE400](http://www.waveshare.com/wiki/BLE400)

--- a/boards.txt
+++ b/boards.txt
@@ -529,6 +529,54 @@ PCA1000X.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
 PCA1000X.menu.lfclk.lfsynt=Synthesized
 PCA1000X.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT
 
+Raytac_MDBT40.name=Raytac MDBT40
+
+Raytac_MDBT40.upload.tool=sandeepmistry:openocd
+Raytac_MDBT40.upload.target=nrf51
+Raytac_MDBT40.upload.maximum_size=262144
+
+Raytac_MDBT40.bootloader.tool=sandeepmistry:openocd
+
+Raytac_MDBT40.build.mcu=cortex-m0
+Raytac_MDBT40.build.f_cpu=16000000
+Raytac_MDBT40.build.board=GENERIC
+Raytac_MDBT40.build.core=nRF5
+Raytac_MDBT40.build.variant=Raytac_MDBT40
+Raytac_MDBT40.build.variant_system_lib=
+Raytac_MDBT40.build.extra_flags=-DNRF51
+Raytac_MDBT40.build.float_flags=
+Raytac_MDBT40.build.ldscript=nrf51_{build.chip}.ld
+
+Raytac_MDBT40.menu.chip.xxaa=16 kB RAM, 256 kB flash (xxaa)
+Raytac_MDBT40.menu.chip.xxaa.build.chip=xxaa
+Raytac_MDBT40.menu.chip.xxac=32 kB RAM, 256 kB flash (xxac)
+Raytac_MDBT40.menu.chip.xxac.build.chip=xxac
+
+Raytac_MDBT40.menu.softdevice.none=None
+Raytac_MDBT40.menu.softdevice.none.softdevice=none
+Raytac_MDBT40.menu.softdevice.none.softdeviceversion=
+
+Raytac_MDBT40.menu.softdevice.s110=S110
+Raytac_MDBT40.menu.softdevice.s110.softdevice=s110
+Raytac_MDBT40.menu.softdevice.s110.softdeviceversion=8.0.0
+Raytac_MDBT40.menu.softdevice.s110.upload.maximum_size=151552
+Raytac_MDBT40.menu.softdevice.s110.build.extra_flags=-DNRF51 -DS110 -DNRF51_S110
+Raytac_MDBT40.menu.softdevice.s110.build.ldscript=armgcc_s110_nrf51822_{build.chip}.ld
+
+Raytac_MDBT40.menu.softdevice.s130=S130
+Raytac_MDBT40.menu.softdevice.s130.softdevice=s130
+Raytac_MDBT40.menu.softdevice.s130.softdeviceversion=2.0.1
+Raytac_MDBT40.menu.softdevice.s130.upload.maximum_size=151552
+Raytac_MDBT40.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
+Raytac_MDBT40.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_{build.chip}.ld
+
+Raytac_MDBT40.menu.lfclk.lfxo=Crystal Oscillator
+Raytac_MDBT40.menu.lfclk.lfxo.build.lfclk_flags=-DUSE_LFXO
+Raytac_MDBT40.menu.lfclk.lfrc=RC Oscillator
+Raytac_MDBT40.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
+Raytac_MDBT40.menu.lfclk.lfsynt=Synthesized
+Raytac_MDBT40.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT
+
 
 nRF51Dongle.name= Nordic nRF51 Dongle (PCA10031)
 

--- a/variants/Raytac_MDBT40/pins_arduino.h
+++ b/variants/Raytac_MDBT40/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/Raytac_MDBT40/variant.cpp
+++ b/variants/Raytac_MDBT40/variant.cpp
@@ -1,0 +1,81 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+
+// Pin map from 0-indexed pin number on the MDBT40 chip to the 
+// digital P0.XX pin numbering scheme
+// taken from https://www.tinyosshop.com/datasheet/MDBT40%20spec-Version%20A4.pdf
+// Lines without comments are P0.XX pins.
+const uint32_t g_ADigitalPinMap[] = {
+    // 0 - 1
+    (uint32_t)-1, // GND
+    (uint32_t)-1, // GND
+
+    // 2 - 11
+    (uint32_t)-1, // AVDD
+    21,
+    22,
+    23,
+    24,
+    25,
+    (uint32_t)-1, // XL2 - crystal
+    (uint32_t)-1, // XL1 - crystal
+    28,
+    29,
+
+    // 12 - 24
+    (uint32_t)-1, // GND
+    (uint32_t)-1, // VDD
+    (uint32_t)-1, // DCC
+    30,
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    (uint32_t)-1, // GND
+    
+    // 25 - 33
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+
+    // 34 - 35
+    (uint32_t)-1, // SWDIO
+    (uint32_t)-1, // SWCLK,
+    
+    // 36 - 41
+    17,
+    18,
+    19,
+    20,
+    (uint32_t)-1, // DEC2
+    (uint32_t)-1, // GND
+};

--- a/variants/Raytac_MDBT40/variant.h
+++ b/variants/Raytac_MDBT40/variant.h
@@ -1,0 +1,102 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_GENERIC_
+#define _VARIANT_GENERIC_
+
+/** Master clock frequency */
+#ifdef NRF52
+#define VARIANT_MCK       (64000000ul)
+#else
+#define VARIANT_MCK       (16000000ul)
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (42u)
+#define NUM_DIGITAL_PINS     (31u)
+#define NUM_ANALOG_INPUTS    (0u)
+#define NUM_ANALOG_OUTPUTS   (0u)
+
+// LEDs
+#define PIN_LED                 (0)
+#define LED_BUILTIN             PIN_LED
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (0)
+#define PIN_A1               (0)
+#define PIN_A2               (0)
+#define PIN_A3               (0)
+#define PIN_A4               (0)
+#define PIN_A5               (0)
+
+static const uint8_t A0  = PIN_A0 ;
+static const uint8_t A1  = PIN_A1 ;
+static const uint8_t A2  = PIN_A2 ;
+static const uint8_t A3  = PIN_A3 ;
+static const uint8_t A4  = PIN_A4 ;
+static const uint8_t A5  = PIN_A5 ;
+#define ADC_RESOLUTION    10
+
+/*
+ * Serial interfaces
+ */
+// Serial
+#define PIN_SERIAL_RX       (4) // P0.22
+#define PIN_SERIAL_TX       (3) // P0.21
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 0
+
+#define PIN_SPI_MISO         (0)
+#define PIN_SPI_MOSI         (0)
+#define PIN_SPI_SCK          (0)
+
+static const uint8_t SS   = 2 ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 0
+
+#define PIN_WIRE_SDA         (0u)
+#define PIN_WIRE_SCL         (0u)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Copies the generic nrf51 and changes the pinout according to the spec for the MDBT40, the module that ships with the XYZrobot 6 DOF Robotic Arm Kit (https://www.pololu.com/product/2743)

I confirmed this allowed me to program one of those modules with an ST-Link V2, flash softdevice 110, and load the serial example. UART communication was working as expected.