### PR TITLE
Added decaWave DWM1001-DEV board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,4 @@ script:
   - buildExampleSketch sandeepmistry:nRF5:bluey 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:hackaBLE 01.Basics Blink
   - buildExampleSketch sandeepmistry:nRF5:Sinobit 01.Basics BareMinimum
+  - buildExampleSketch sandeepmistry:nRF5:DWM1001-DEV 01.Basics Blink

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Become a sponsor and get your logo on our README on Github with a link to your s
  * [RedBear Nano 2](https://github.com/redbear/nRF5x#ble-nano-2)
  * [Bluey](https://github.com/electronut/ElectronutLabs-bluey)
  * [hackaBLE](https://github.com/electronut/ElectronutLabs-hackaBLE)
+ * [DWM1001-DEV](https://www.decawave.com/product/dwm1001-development-board/)
 
 ### nRF51
  * [Plain nRF51 MCU](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822)

--- a/boards.txt
+++ b/boards.txt
@@ -912,3 +912,32 @@ Sinobit.menu.softdevice.s130.softdeviceversion=2.0.1
 Sinobit.menu.softdevice.s130.upload.maximum_size=151552
 Sinobit.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 Sinobit.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxaa.ld
+
+DWM1001-DEV.name=decaWave DWM1001 Module Development Board
+
+DWM1001-DEV.upload.tool=sandeepmistry:openocd
+DWM1001-DEV.upload.protocol=jlink
+DWM1001-DEV.upload.target=nrf52
+DWM1001-DEV.upload.maximum_size=524288
+DWM1001-DEV.upload.setup_command=transport select swd;
+DWM1001-DEV.upload.use_1200bps_touch=false
+DWM1001-DEV.upload.wait_for_upload_port=false
+DWM1001-DEV.upload.native_usb=false
+
+DWM1001-DEV.bootloader.tool=sandeepmistry:openocd
+
+DWM1001-DEV.build.mcu=cortex-m4
+DWM1001-DEV.build.f_cpu=16000000
+DWM1001-DEV.build.board=DWM1001-DEV
+DWM1001-DEV.build.core=nRF5
+DWM1001-DEV.build.variant=DWM1001-DEV
+DWM1001-DEV.build.variant_system_lib=
+DWM1001-DEV.build.extra_flags=-DNRF52
+DWM1001-DEV.build.float_flags=-mfloat-abi=hard -mfpu=fpv4-sp-d16
+DWM1001-DEV.build.ldscript=nrf52_xxaa.ld
+
+DWM1001-DEV.build.lfclk_flags=-DUSE_LFXO
+
+DWM1001-DEV.menu.softdevice.none=None
+DWM1001-DEV.menu.softdevice.none.softdevice=none
+DWM1001-DEV.menu.softdevice.none.softdeviceversion=

--- a/boards.txt
+++ b/boards.txt
@@ -928,7 +928,7 @@ DWM1001-DEV.bootloader.tool=sandeepmistry:openocd
 
 DWM1001-DEV.build.mcu=cortex-m4
 DWM1001-DEV.build.f_cpu=16000000
-DWM1001-DEV.build.board=DWM1001-DEV
+DWM1001-DEV.build.board=DWM1001_DEV
 DWM1001-DEV.build.core=nRF5
 DWM1001-DEV.build.variant=DWM1001-DEV
 DWM1001-DEV.build.variant_system_lib=

--- a/boards.txt
+++ b/boards.txt
@@ -941,3 +941,10 @@ DWM1001-DEV.build.lfclk_flags=-DUSE_LFXO
 DWM1001-DEV.menu.softdevice.none=None
 DWM1001-DEV.menu.softdevice.none.softdevice=none
 DWM1001-DEV.menu.softdevice.none.softdeviceversion=
+
+DWM1001-DEV.menu.softdevice.s132=S132
+DWM1001-DEV.menu.softdevice.s132.softdevice=s132
+DWM1001-DEV.menu.softdevice.s132.softdeviceversion=2.0.1
+DWM1001-DEV.menu.softdevice.s132.upload.maximum_size=409600
+DWM1001-DEV.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+DWM1001-DEV.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld

--- a/variants/DWM1001-DEV/pins_arduino.h
+++ b/variants/DWM1001-DEV/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/DWM1001-DEV/variant.cpp
+++ b/variants/DWM1001-DEV/variant.cpp
@@ -20,9 +20,7 @@
 #include "variant.h"
 
 const uint32_t g_ADigitalPinMap[] = {
-  // D0 - D10
-  1,
-  0,
+  // D0 - D8
   12,
   27,
   23,

--- a/variants/DWM1001-DEV/variant.cpp
+++ b/variants/DWM1001-DEV/variant.cpp
@@ -1,0 +1,70 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  // D0 - D10
+  1,
+  0,
+  12,
+  27,
+  23,
+  13,
+  15,
+  8,
+  26,
+  6,
+  7,
+
+  // A0, A1
+  4,
+  3,
+
+  // SDA, SCL
+  29,
+  28,
+
+  // RX, TX
+  11,
+  5,
+
+  // DWM1000
+  // SPI SS1, MISO1, MOSI1, SCK1
+  17,
+  18,
+  20,
+  16,
+  // RST, IRQ
+  24,
+  19,
+
+  // ACC IRQ
+  25,
+
+  // LEDS
+  14,
+  22,
+  30,
+  31,
+
+  // BTN
+  2
+
+};

--- a/variants/DWM1001-DEV/variant.h
+++ b/variants/DWM1001-DEV/variant.h
@@ -1,0 +1,134 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_DWM1001-DEV_
+#define _VARIANT_DWM1001-DEV_
+
+/** Master clock frequency */
+#define VARIANT_MCK       (64000000ul)
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (29u)
+#define NUM_DIGITAL_PINS     (13u)
+#define NUM_ANALOG_INPUTS    (2u)
+#define NUM_ANALOG_OUTPUTS   (0u)
+
+// LEDs
+#define PIN_LEDRT            (24)
+#define PIN_LEDRB            (25)
+#define PIN_LEDG             (26)
+#define PIN_LEDB             (27)
+#define LED_BUILTIN          PIN_LEDRT
+static const uint8_t LED_RED_TOP = PIN_LEDRT ;
+static const uint8_t LED_RED_BOT = PIN_LEDRB ;
+static const uint8_t LED_GREEN   = PIN_LEDG ;
+static const uint8_t LED_BLUE    = PIN_LEDB ;
+
+// Button
+#define PIN_BUTTON           (28)
+
+static const uint8_t BTN = PIN_BUTTON ;
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (11)
+#define PIN_A1               (15)
+
+static const uint8_t A0  = PIN_A0 ; // AIN2
+static const uint8_t A1  = PIN_A1 ; // AIN1
+#define ADC_RESOLUTION    14
+
+/*
+ * Serial interfaces
+ */
+// Serial
+#define PIN_SERIAL_RX       (15)
+#define PIN_SERIAL_TX       (16)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 2
+
+#define PIN_SPI_MISO         (10)
+#define PIN_SPI_MOSI         (9)
+#define PIN_SPI_SCK          (PIN_A0)
+
+static const uint8_t SS   = PIN_A1 ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+#define PIN_SPI1_SS          (17)
+#define PIN_SPI1_MISO        (18)
+#define PIN_SPI1_MOSI        (19)
+#define PIN_SPI1_SCK         (20)
+
+static const uint8_t SS1   = PIN_SPI1_SS ;
+static const uint8_t MOSI1 = PIN_SPI1_MOSI ;
+static const uint8_t MISO1 = PIN_SPI1_MISO ;
+static const uint8_t SCK1  = PIN_SPI1_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA         (13)
+#define PIN_WIRE_SCL         (14)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+/*
+ * Reset Button at P0.21
+ */
+#define RESET_PIN            21
+
+/*
+ * Other DWM1001 internal IOs
+ */
+#define PIN_DW_RST           (21)
+#define PIN_DW_IRQ           (22)
+
+static const uint8_t DW_RST = PIN_DW_RST;
+static const uint8_t DW_IRQ = PIN_DW_IRQ;
+
+#define PIN_ACC_IRQ          (23)
+
+static const uint8_t ACC_IRQ = PIN_ACC_IRQ;
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif

--- a/variants/DWM1001-DEV/variant.h
+++ b/variants/DWM1001-DEV/variant.h
@@ -14,8 +14,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _VARIANT_DWM1001-DEV_
-#define _VARIANT_DWM1001-DEV_
+#ifndef _VARIANT_DWM1001_DEV_
+#define _VARIANT_DWM1001_DEV_
 
 /** Master clock frequency */
 #define VARIANT_MCK       (64000000ul)

--- a/variants/DWM1001-DEV/variant.h
+++ b/variants/DWM1001-DEV/variant.h
@@ -32,16 +32,16 @@ extern "C"
 #endif // __cplusplus
 
 // Number of pins defined in PinDescription array
-#define PINS_COUNT           (29u)
-#define NUM_DIGITAL_PINS     (13u)
+#define PINS_COUNT           (27u)
+#define NUM_DIGITAL_PINS     (11u)
 #define NUM_ANALOG_INPUTS    (2u)
 #define NUM_ANALOG_OUTPUTS   (0u)
 
 // LEDs
-#define PIN_LEDRT            (24)
-#define PIN_LEDRB            (25)
-#define PIN_LEDG             (26)
-#define PIN_LEDB             (27)
+#define PIN_LEDRT            (22)
+#define PIN_LEDRB            (23)
+#define PIN_LEDG             (24)
+#define PIN_LEDB             (25)
 #define LED_BUILTIN          PIN_LEDRT
 static const uint8_t LED_RED_TOP = PIN_LEDRT ;
 static const uint8_t LED_RED_BOT = PIN_LEDRB ;
@@ -49,15 +49,15 @@ static const uint8_t LED_GREEN   = PIN_LEDG ;
 static const uint8_t LED_BLUE    = PIN_LEDB ;
 
 // Button
-#define PIN_BUTTON           (28)
+#define PIN_BUTTON           (26)
 
 static const uint8_t BTN = PIN_BUTTON ;
 
 /*
  * Analog pins
  */
-#define PIN_A0               (11)
-#define PIN_A1               (15)
+#define PIN_A0               (9)
+#define PIN_A1               (10)
 
 static const uint8_t A0  = PIN_A0 ; // AIN2
 static const uint8_t A1  = PIN_A1 ; // AIN1
@@ -67,16 +67,16 @@ static const uint8_t A1  = PIN_A1 ; // AIN1
  * Serial interfaces
  */
 // Serial
-#define PIN_SERIAL_RX       (15)
-#define PIN_SERIAL_TX       (16)
+#define PIN_SERIAL_RX       (13)
+#define PIN_SERIAL_TX       (14)
 
 /*
  * SPI Interfaces
  */
 #define SPI_INTERFACES_COUNT 2
 
-#define PIN_SPI_MISO         (10)
-#define PIN_SPI_MOSI         (9)
+#define PIN_SPI_MISO         (8)
+#define PIN_SPI_MOSI         (7)
 #define PIN_SPI_SCK          (PIN_A0)
 
 static const uint8_t SS   = PIN_A1 ;
@@ -84,10 +84,10 @@ static const uint8_t MOSI = PIN_SPI_MOSI ;
 static const uint8_t MISO = PIN_SPI_MISO ;
 static const uint8_t SCK  = PIN_SPI_SCK ;
 
-#define PIN_SPI1_SS          (17)
-#define PIN_SPI1_MISO        (18)
-#define PIN_SPI1_MOSI        (19)
-#define PIN_SPI1_SCK         (20)
+#define PIN_SPI1_SS          (15)
+#define PIN_SPI1_MISO        (16)
+#define PIN_SPI1_MOSI        (17)
+#define PIN_SPI1_SCK         (18)
 
 static const uint8_t SS1   = PIN_SPI1_SS ;
 static const uint8_t MOSI1 = PIN_SPI1_MOSI ;
@@ -99,8 +99,8 @@ static const uint8_t SCK1  = PIN_SPI1_SCK ;
  */
 #define WIRE_INTERFACES_COUNT 1
 
-#define PIN_WIRE_SDA         (13)
-#define PIN_WIRE_SCL         (14)
+#define PIN_WIRE_SDA         (11)
+#define PIN_WIRE_SCL         (12)
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
@@ -113,13 +113,13 @@ static const uint8_t SCL = PIN_WIRE_SCL;
 /*
  * Other DWM1001 internal IOs
  */
-#define PIN_DW_RST           (21)
-#define PIN_DW_IRQ           (22)
+#define PIN_DW_RST           (19)
+#define PIN_DW_IRQ           (20)
 
 static const uint8_t DW_RST = PIN_DW_RST;
 static const uint8_t DW_IRQ = PIN_DW_IRQ;
 
-#define PIN_ACC_IRQ          (23)
+#define PIN_ACC_IRQ          (21)
 
 static const uint8_t ACC_IRQ = PIN_ACC_IRQ;
 


### PR DESCRIPTION
Hi,

I have added support for decaWave DWM1001-DEV board. I am not working for decaWave so this is an **unofficial** port. I have tried to optimize the pinout based on the available pins. [Here](https://github.com/sandeepmistry/arduino-nRF5/files/2495097/dwm1001-dev_arduino_pinout.pdf) is a document explaining the pinout.

It would be great if you could merge it.

Thanks