### PR TITLE
boards: hackaBLE fix pin mapping

### DIFF
--- a/variants/hackaBLE/variant.cpp
+++ b/variants/hackaBLE/variant.cpp
@@ -19,60 +19,38 @@
 
 #include "variant.h"
 
-/*
-                                Top view
-            RX - D0 | P0.14                 P0.27 | D7  - SDA
-            Tx - D1 | P0.13                 P0.26 | D8  - SCL
-                 D2 | P0.12                 P0.25 | D9
-            SS - D3 | P0.11            AIN3/P0.05 | D10 - A3
-          MISO - D4 | P0.08            AIN2/P0.04 | D11 - A2
-          MOSI - D5 | P0.07            AIN1/P0.03 | D12 - A1
-           SCK - D6 | P0.06            AIN0/P0.02 | D13 - A0
-                    | NFC2/P0.10            Vin   |
-                    | NFC1/P0.09            Gnd   |
-
-
-                            Bottom view (smt pads)
-                  D19 | P0.24            P0.23 | D14
-             A4 - D20 | P0.28/AIN4       P0.22 | D15
-             A5 - D21 | P0.29/AIN5       P0.18 | D16
-             A6 - D22 | P0.30/AIN6       P0.16 | D17
-             A7 - D23 | P0.31/AIN7       P0.15 | D18
-
-
-                      LEDs
-                  Red   - P0.19 | D24
-                  Green - P0.19 | D25
-                  Blue  - P0.19 | D26 - LED_BUILTIN
-
-*/
 
 const uint32_t g_ADigitalPinMap[] = {
-  14,
-  13,
-  12,
-  11,
-  8,
-  7,
-  6,
-  27,
-  26,
-  25,
-  5,
-  4,
-  3,
+  0,
+  1,
   2,
-  23,
-  22,
-  18,
-  16,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
   15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
   24,
+  25,
+  26,
+  27,
   28,
   29,
   30,
-  31,
-  19,
-  20,
-  17,
+  31
 };

--- a/variants/hackaBLE/variant.h
+++ b/variants/hackaBLE/variant.h
@@ -32,28 +32,28 @@ extern "C"
 #endif // __cplusplus
 
 // Number of pins defined in PinDescription array
-#define PINS_COUNT           (27u)
-#define NUM_DIGITAL_PINS     (27u)
+#define PINS_COUNT           (32u)
+#define NUM_DIGITAL_PINS     (32u)
 #define NUM_ANALOG_INPUTS    (8u)
 #define NUM_ANALOG_OUTPUTS   (0u)
 
 // LEDs
-#define PIN_LEDR               (24)
-#define PIN_LEDG               (25)
-#define PIN_LEDB               (26)
+#define PIN_LEDR               (19)
+#define PIN_LEDG               (20)
+#define PIN_LEDB               (17)
 #define LED_BUILTIN            PIN_LEDB
 
 /*
  * Analog pins
  */
-#define PIN_A0               (13)
-#define PIN_A1               (12)
-#define PIN_A2               (11)
-#define PIN_A3               (10)
-#define PIN_A4               (20)
-#define PIN_A5               (21)
-#define PIN_A6               (22)
-#define PIN_A7               (23)
+#define PIN_A0               (2)
+#define PIN_A1               (3)
+#define PIN_A2               (4)
+#define PIN_A3               (5)
+#define PIN_A4               (28)
+#define PIN_A5               (29)
+#define PIN_A6               (30)
+#define PIN_A7               (31)
 
 static const uint8_t A0  = PIN_A0 ; // AIN0 / AREF / P0.02
 static const uint8_t A1  = PIN_A1 ; // AIN1
@@ -73,18 +73,18 @@ static const uint8_t AREF = PIN_AREF;
  * Serial interfaces
  */
 // Serial
-#define PIN_SERIAL_RX       (0)
-#define PIN_SERIAL_TX       (1)
+#define PIN_SERIAL_RX       (7)
+#define PIN_SERIAL_TX       (8)
 
 /*
  * SPI Interfaces
  */
 #define SPI_INTERFACES_COUNT 1
 
-#define PIN_SPI_MISO         (4)
-#define PIN_SPI_MOSI         (3)
-#define PIN_SPI_SCK          (5)
-#define PIN_SPI_SS           (3)
+#define PIN_SPI_MISO         (11)
+#define PIN_SPI_MOSI         (12)
+#define PIN_SPI_SCK          (13)
+#define PIN_SPI_SS           (14)
 
 static const uint8_t SS   = PIN_SPI_SS ;
 static const uint8_t MOSI = PIN_SPI_MOSI ;
@@ -96,8 +96,8 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
  */
 #define WIRE_INTERFACES_COUNT 1
 
-#define PIN_WIRE_SDA         (7)
-#define PIN_WIRE_SCL         (8)
+#define PIN_WIRE_SDA         (2)
+#define PIN_WIRE_SCL         (3)
 
 /*
  * Reset Button at P0.21


### PR DESCRIPTION
There are two version of hackaBLE with different pins exposed.
This change makes nRF52832 pins map directly to Arduino pins
sequentially.

Signed-off-by: vaishali <vaishali@electronut.in>