### PR TITLE
fix for "undefined reference to `vtable for HardwareSerial'"

### DIFF
--- a/cores/nRF5/HardwareSerial.h
+++ b/cores/nRF5/HardwareSerial.h
@@ -67,9 +67,9 @@
 class HardwareSerial : public Stream
 {
   public:
-    virtual void begin(unsigned long);
-    virtual void begin(unsigned long baudrate, uint16_t config);
-    virtual void end();
+    virtual void begin(unsigned long) = 0;
+    virtual void begin(unsigned long baudrate, uint16_t config) = 0;
+    virtual void end() = 0;
     virtual int available(void) = 0;
     virtual int peek(void) = 0;
     virtual int read(void) = 0;


### PR DESCRIPTION
Not all functions of HardwareSerial are declared as pure virtual. This leads to "undefined reference to `vtable for HardwareSerial'" errors when used via Segger Studio.