### PR TITLE
Fix for broken SPI.h

### DIFF
--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -155,3 +155,5 @@ extern SPIClass SPI1;
 #define SPI_CLOCK_DIV64  64 * DIVISOR
 #define SPI_CLOCK_DIV128 128 * DIVISOR
 #endif
+
+#endif


### PR DESCRIPTION
After commit https://github.com/sandeepmistry/arduino-nRF5/commit/0524008cca0432dba9da0dac5e665bb50ae7cd25#diff-ddd77aecb16ad4a70bea9989e9fd8022 the preprocessor if's are unbalanced. That endif as suggested in this pull request therefore should be added again.