### PR TITLE
ID115 fitness bracelet board support

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1024,3 +1024,50 @@ SeeedArchLink.menu.softdevice.s130.upload.maximum_size=151552
 SeeedArchLink.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 SeeedArchLink.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxaa.ld
 
+ID115.name=ID115
+
+ID115.upload.tool=sandeepmistry:openocd
+ID115.upload.target=nrf51
+ID115.upload.maximum_size=262144
+
+ID115.bootloader.tool=sandeepmistry:openocd
+
+ID115.build.mcu=cortex-m0
+ID115.build.f_cpu=16000000
+ID115.build.board=ID115
+ID115.build.core=nRF5
+ID115.build.variant=ID115
+ID115.build.variant_system_lib=
+ID115.build.extra_flags=-DNRF51
+ID115.build.float_flags=
+ID115.build.ldscript=nrf51_{build.chip}.ld
+
+ID115.menu.chip.xxaa=16 kB RAM, 256 kB flash (xxaa)
+ID115.menu.chip.xxaa.build.chip=xxaa
+ID115.menu.chip.xxac=32 kB RAM, 256 kB flash (xxac)
+ID115.menu.chip.xxac.build.chip=xxac
+
+ID115.menu.softdevice.none=None
+ID115.menu.softdevice.none.softdevice=none
+ID115.menu.softdevice.none.softdeviceversion=
+
+ID115.menu.softdevice.s110=S110
+ID115.menu.softdevice.s110.softdevice=s110
+ID115.menu.softdevice.s110.softdeviceversion=8.0.0
+ID115.menu.softdevice.s110.upload.maximum_size=151552
+ID115.menu.softdevice.s110.build.extra_flags=-DNRF51 -DS110 -DNRF51_S110
+ID115.menu.softdevice.s110.build.ldscript=armgcc_s110_nrf51822_{build.chip}.ld
+
+ID115.menu.softdevice.s130=S130
+ID115.menu.softdevice.s130.softdevice=s130
+ID115.menu.softdevice.s130.softdeviceversion=2.0.1
+ID115.menu.softdevice.s130.upload.maximum_size=151552
+ID115.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
+ID115.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_{build.chip}.ld
+
+ID115.menu.lfclk.lfxo=Crystal Oscillator
+ID115.menu.lfclk.lfxo.build.lfclk_flags=-DUSE_LFXO
+ID115.menu.lfclk.lfrc=RC Oscillator
+ID115.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
+ID115.menu.lfclk.lfsynt=Synthesized
+ID115.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT

--- a/variants/ID115/pins_arduino.h
+++ b/variants/ID115/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/ID115/variant.cpp
+++ b/variants/ID115/variant.cpp
@@ -1,0 +1,52 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
+  24,
+  25,
+  26,
+  27,
+  28,
+  29,
+  30,
+  31
+};

--- a/variants/ID115/variant.h
+++ b/variants/ID115/variant.h
@@ -1,0 +1,117 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
+  This particular adaption for ID115 was originally created by @rbaron
+  https://github.com/rbaron/arduino-nRF5
+*/
+
+#ifndef _VARIANT_ID115_
+#define _VARIANT_ID115_
+
+/** Master clock frequency */
+#ifdef NRF52
+#define VARIANT_MCK       (64000000ul)
+#else
+#define VARIANT_MCK       (16000000ul)
+#define F_CPU VARIANT_MCK
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (32u)
+#define NUM_DIGITAL_PINS     (32u)
+#define NUM_ANALOG_INPUTS    (6u)
+#define NUM_ANALOG_OUTPUTS   (0u)
+
+// LEDs
+
+// TX pad on the ID115 board. The board doesn't have a built-in LED,
+// so it's just a good place to put one
+#define PIN_LED              (0) // P0.0
+#define LED_BUILTIN          PIN_LED
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (1) // P0.01
+#define PIN_A1               (2) // P0.02
+#define PIN_A2               (3) // P0.03
+#define PIN_A3               (4) // P0.04
+#define PIN_A4               (5) // P0.05
+#define PIN_A5               (6) // P0.06
+
+static const uint8_t A0  = PIN_A0 ;
+static const uint8_t A1  = PIN_A1 ;
+static const uint8_t A2  = PIN_A2 ;
+static const uint8_t A3  = PIN_A3 ;
+static const uint8_t A4  = PIN_A4 ;
+static const uint8_t A5  = PIN_A5 ;
+#ifdef NRF52
+#define ADC_RESOLUTION    14
+#else
+#define ADC_RESOLUTION    10
+#endif
+
+/*
+ * Serial interfaces
+ */
+// Serial
+#define PIN_SERIAL_RX       (30) // P0.30
+#define PIN_SERIAL_TX       (0) // P0.00
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+
+#define PIN_SPI_MISO         (22) // P0.22
+#define PIN_SPI_MOSI         (23) // P0.23
+#define PIN_SPI_SCK          (24) // P0.24
+
+static const uint8_t SS   = 25 ;  // P0.25
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA         (21u) // P0.21
+#define PIN_WIRE_SCL         (22u) // P0.22
+#define PIN_WIRE_RST         (24u) // P0.22
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+static const uint8_t RST = PIN_WIRE_RST;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
The ID115 is a NRF51 based fitness tracker that is sometimes sold for as little as 8 USD. The combination of low cost, compact size and a rechargeable battery makes it rather compelling for little hacking projects.

Credits for this pull request go to @rbaron. What's submitted here is basically a copy from his repository. I only removed the LF Crystal option in boards.txt because this hardware doesn't have such a LF crystal.

More information about the hardware including an adapted driver for the OLED can be found on his blog: https://rbaron.net/blog/2018/05/27/Hacking-a-cheap-fitness-tracker-bracelet.html

For people interested in ordering this hardware it's worth pointing out that there are slightly different hardware revisions (the one I've got is nRF51802 based and there is a minor difference in the OLED memory layout too). Also some shops sell an entirely different hardware with a chinese BLE SoC as ID115, so compare the product pictures carefully before ordering and be prepared that things might not just work out of the box.