### PR TITLE
Add support for RAK iTracker

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1024,3 +1024,34 @@ SeeedArchLink.menu.softdevice.s130.upload.maximum_size=151552
 SeeedArchLink.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 SeeedArchLink.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxaa.ld
 
+iTracker.name=iTracker
+
+iTracker.upload.tool=sandeepmistry:openocd
+iTracker.upload.protocol=jlink
+iTracker.upload.target=nrf52
+iTracker.upload.maximum_size=524288
+iTracker.upload.setup_command=transport select swd;
+iTracker.upload.use_1200bps_touch=false
+iTracker.upload.wait_for_upload_port=false
+iTracker.upload.native_usb=false
+
+iTracker.bootloader.tool=sandeepmistry:openocd
+
+iTracker.build.mcu=cortex-m4
+iTracker.build.f_cpu=16000000
+iTracker.build.board=iTracker
+iTracker.build.core=nRF5
+iTracker.build.variant=iTracker
+iTracker.build.variant_system_lib=
+iTracker.build.extra_flags=-DNRF52
+iTracker.build.float_flags=-mfloat-abi=hard -mfpu=fpv4-sp-d16
+iTracker.build.ldscript=nrf52_xxaa.ldiTracker.build.lfclk_flags=-DUSE_LFXO
+
+iTracker.menu.softdevice.none=None
+iTracker.menu.softdevice.none.softdevice=none
+iTracker.menu.softdevice.s132=S132
+iTracker.menu.softdevice.s132.softdevice=s132
+iTracker.menu.softdevice.s132.softdeviceversion=2.0.1
+iTracker.menu.softdevice.s132.upload.maximum_size=409600
+iTracker.menu.softdevice.s132.build.extra_flags=-DNRF52-DS132 -DNRF51_S132
+iTracker.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld

--- a/variants/iTracker/pins_arduino.h
+++ b/variants/iTracker/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/iTracker/variant.cpp
+++ b/variants/iTracker/variant.cpp
@@ -1,0 +1,58 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  // D0 - D7
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+
+  // D8 - D13
+  19,
+  20,
+  22,
+  23,
+  24,
+  25,
+
+  // A0 - A7
+  3,
+  4,
+  28,
+  29,
+  30,
+  31,
+  5, // AIN3 (P0.05)
+  2, // AIN0 (P0.02) / AREF
+
+  // SDA, SCL
+  26,
+  27,
+
+  // RX, TX
+  8,
+  6
+};

--- a/variants/iTracker/variant.h
+++ b/variants/iTracker/variant.h
@@ -1,0 +1,137 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_NRF52_DK_
+#define _VARIANT_NRF52_DK_
+
+/** Master clock frequency */
+#define VARIANT_MCK       (64000000ul)
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (26u)
+#define NUM_DIGITAL_PINS     (20u)
+#define NUM_ANALOG_INPUTS    (8u)
+#define NUM_ANALOG_OUTPUTS   (0u)
+
+// LEDs
+#define PIN_LED1                (6)
+#define PIN_LED2                (7)
+#define PIN_LED3                (8)
+#define PIN_LED4                (9)
+#define LED_BUILTIN             PIN_LED1
+
+// Buttons
+#define PIN_BUTTON1             (2)
+#define PIN_BUTTON2             (3)
+#define PIN_BUTTON3             (4)
+#define PIN_BUTTON4             (5)
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (14)
+#define PIN_A1               (15)
+#define PIN_A2               (16)
+#define PIN_A3               (17)
+#define PIN_A4               (18)
+#define PIN_A5               (19)
+#define PIN_A6               (20) /* AIN3 (P0.05)        */
+#define PIN_A7               (21) /* AIN0 (P0.02) / AREF */
+
+static const uint8_t A0  = PIN_A0 ; // AIN1
+static const uint8_t A1  = PIN_A1 ; // AIN2
+static const uint8_t A2  = PIN_A2 ; // AIN4
+static const uint8_t A3  = PIN_A3 ; // AIN5
+static const uint8_t A4  = PIN_A4 ; // AIN6
+static const uint8_t A5  = PIN_A5 ; // AIN7
+static const uint8_t A6  = PIN_A6 ; // AIN3 (P0.05)
+static const uint8_t A7  = PIN_A7 ; // AIN0 (P0.02) / AREF
+#define ADC_RESOLUTION    14
+
+// Other pins
+#define PIN_AREF           (21)
+static const uint8_t AREF = PIN_AREF;
+
+/*
+ * Serial interfaces
+ */
+ //swap PIN_SERIAL* and PIN_SERIAL1* to send serial data to GSM module
+ 
+// Serial pins for usb connector
+#define PIN_SERIAL_RX       (16)
+#define PIN_SERIAL_TX       (17)
+
+// Serial pins for LTE
+#define PIN_SERIAL1_RX      (1)
+#define PIN_SERIAL1_TX      (9)
+
+/*
+ * GSM (LTE)
+ */
+//Set power to the GSM module
+#define GSM_ON              (25)
+//Boot the GSM module
+#define GSM_PWRKEY          (4)
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+
+#define PIN_SPI_MISO         (12)
+#define PIN_SPI_MOSI         (11)
+#define PIN_SPI_SCK          (13)
+
+static const uint8_t SS   = 10 ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA         (22u)
+#define PIN_WIRE_SCL         (23u)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+/*
+ * Reset Button at P0.21
+ */
+#define RESET_PIN            21
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
adds support for the RAK8212 module.

They have already a manual for it to add it manual so why not add it in the release?
Added some pins for the GSM module:
- GSM_ON
- GSM_PWRKEY

[https://www.rakwireless.com/en/download/Cellular/RAK8212#Software-Development](https://www.rakwireless.com/en/download/Cellular/RAK8212#Software-Development)