### PR TITLE
Add _BV

### DIFF
--- a/cores/nRF5/Arduino.h
+++ b/cores/nRF5/Arduino.h
@@ -91,6 +91,7 @@ void loop( void ) ;
 #define bitWrite(value, bit, bitvalue) (bitvalue ? bitSet(value, bit) : bitClear(value, bit))
 
 #define bit(b) (1UL << (b))
+#define _BV(b) (1UL << (b))
 
 #define digitalPinToPort(P)        ( &(NRF_GPIO[P]) )
 #define digitalPinToBitMask(P)     ( 1 << g_ADigitalPinMap[P] )


### PR DESCRIPTION
I want to use a library but it fails build on arduino-nRF5 because of missing `_BV`.
Could add it?

Thank you.

References:
[error: '_BV' was not declared in this scope](https://github.com/esp8266/Arduino/issues/125)
[Merge pull request #127 from Links2004/esp8266](https://github.com/esp8266/Arduino/commit/f1e6a72d8cb628cd8fa82d6ee11e97acef469b17)