### PR TITLE
Fix #312: softdevice download links should be stable now.

### DIFF
--- a/softdevices.txt
+++ b/softdevices.txt
@@ -1,10 +1,11 @@
 names=s110,s130,s132
 
-s110.url=http://www.nordicsemi.com/eng/content/download/80234/1351257/file/s110_nrf51_8.0.0.zip
+s110.url=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SoftDevices/S110/s110nrf51800.zip
 s110.filename=s110_nrf51_8.0.0_softdevice.hex
 
-s130.url=http://www.nordicsemi.com/eng/content/download/95150/1606929/file/s130_nrf51_2.0.1.zip
+s130.url=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SoftDevices/S130/s130nrf51201.zip
 s130.filename=s130_nrf51_2.0.1_softdevice.hex
 
-s132.url=http://www.nordicsemi.com/eng/content/download/95151/1606944/file/s132_nrf52_2.0.1.zip
+s132.url=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SoftDevices/S132/s132nrf52201.zip
 s132.filename=s132_nrf52_2.0.1_softdevice.hex
+


### PR DESCRIPTION
Hi all!
As you can see in the commit, the new URLs look more "durable", so this commit should fix the download problem for a while.

Note: to avoid changing any behavior, this commit only allows downloading the exact same versions of the SD, but there are much more recent ones:
https://www.nordicsemi.com/Software-and-tools/Software/S132/Download#infotabs
https://www.nordicsemi.com/Software-and-tools/Software/S130/Download#infotabs

=> If any of you is confident about the retro-compatibility of the new SD, I'd be happy to improve this pull request.

Thanks again for this great project!
Cedric ;)