### PR TITLE
Add support for Pine64 PineTime watch

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1024,3 +1024,40 @@ SeeedArchLink.menu.softdevice.s130.upload.maximum_size=151552
 SeeedArchLink.menu.softdevice.s130.build.extra_flags=-DNRF51 -DS130 -DNRF51_S130
 SeeedArchLink.menu.softdevice.s130.build.ldscript=armgcc_s130_nrf51822_xxaa.ld
 
+
+
+Pinetime.name=PineTime
+
+Pinetime.upload.tool=sandeepmistry:openocd
+Pinetime.upload.target=nrf52
+Pinetime.upload.maximum_size=524288
+
+Pinetime.bootloader.tool=sandeepmistry:openocd
+
+Pinetime.build.mcu=cortex-m4
+Pinetime.build.f_cpu=16000000
+Pinetime.build.board=PINETIME
+Pinetime.build.core=nRF5
+Pinetime.build.variant=Pinetime
+Pinetime.build.variant_system_lib=
+Pinetime.build.extra_flags=-DNRF52
+Pinetime.build.float_flags=-mfloat-abi=hard -mfpu=fpv4-sp-d16
+Pinetime.build.ldscript=nrf52_xxaa.ld
+
+Pinetime.menu.softdevice.none=None
+Pinetime.menu.softdevice.none.softdevice=none
+Pinetime.menu.softdevice.none.softdeviceversion=
+
+Pinetime.menu.softdevice.s132=S132
+Pinetime.menu.softdevice.s132.softdevice=s132
+Pinetime.menu.softdevice.s132.softdeviceversion=2.0.1
+Pinetime.menu.softdevice.s132.upload.maximum_size=409600
+Pinetime.menu.softdevice.s132.build.extra_flags=-DNRF52 -DS132 -DNRF51_S132
+Pinetime.menu.softdevice.s132.build.ldscript=armgcc_s132_nrf52832_xxaa.ld
+
+Pinetime.menu.lfclk.lfxo=Crystal Oscillator
+Pinetime.menu.lfclk.lfxo.build.lfclk_flags=-DUSE_LFXO
+Pinetime.menu.lfclk.lfrc=RC Oscillator
+Pinetime.menu.lfclk.lfrc.build.lfclk_flags=-DUSE_LFRC
+Pinetime.menu.lfclk.lfsynt=Synthesized
+Pinetime.menu.lfclk.lfsynt.build.lfclk_flags=-DUSE_LFSYNT

--- a/variants/PineTime/pins_arduino.h
+++ b/variants/PineTime/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/PineTime/variant.cpp
+++ b/variants/PineTime/variant.cpp
@@ -1,0 +1,55 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
+  24,
+  25,
+  26,
+  27,
+  28,
+  29,
+  30,
+  31
+};

--- a/variants/PineTime/variant.h
+++ b/variants/PineTime/variant.h
@@ -1,0 +1,100 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_PINETIME_
+#define _VARIANT_PINETIME_
+
+/** Master clock frequency */
+#define  NRF52
+#define VARIANT_MCK       (64000000ul)
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (32u)
+#define NUM_DIGITAL_PINS     (32u)
+#define NUM_ANALOG_INPUTS    (6u)
+#define NUM_ANALOG_OUTPUTS   (0u)
+
+// LEDs
+#define PIN_LED              (23)
+#define LED_BUILTIN          PIN_LED
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (4) // P0.01
+#define PIN_A1               (5) // P0.02
+#define PIN_A2               (28) // P0.03
+#define PIN_A3               (29) // P0.04
+#define PIN_A4               (30) // P0.05
+#define PIN_A5               (31) // P0.06
+
+static const uint8_t A0  = PIN_A0 ;
+static const uint8_t A1  = PIN_A1 ;
+static const uint8_t A2  = PIN_A2 ;
+static const uint8_t A3  = PIN_A3 ;
+static const uint8_t A4  = PIN_A4 ;
+static const uint8_t A5  = PIN_A5 ;
+#define ADC_RESOLUTION    14
+
+/*
+ * Serial interfaces
+ */
+// Serial (only TXD is refrenced in schematic)
+#define PIN_SERIAL_RX       (17)
+#define PIN_SERIAL_TX       (11)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+
+#define PIN_SPI_MISO         (4)
+#define PIN_SPI_MOSI         (3)
+#define PIN_SPI_SCK          (2)
+
+static const uint8_t SS   = 25 ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA         (6)
+#define PIN_WIRE_SCL         (7)
+
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
The Pinetime is an inexpensive watch from Pine64 using an NRF52832. This adds a new variant with the correct pinout for SPI & I2C. As the watch doesn't have a separate LED, I've defined one of the LCD backlight pins as the LED_BUILTIN