### PR TITLE
Fixing pgm_read_ptr macro bug

### DIFF
--- a/cores/nRF5/avr/pgmspace.h
+++ b/cores/nRF5/avr/pgmspace.h
@@ -102,7 +102,7 @@ typedef const void* uint_farptr_t;
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #define pgm_read_float(addr) (*(const float *)(addr))
-#define pgm_read_ptr(addr) (*(const void *)(addr))
+#define pgm_read_ptr(addr) (*(const void* *)(addr))
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)


### PR DESCRIPTION
Bugfix PR for pgm_read_ptr macro. See also:

- https://github.com/adafruit/Adafruit_nRF52_Arduino/issues/502 (spotted and fixed by me)
- https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/avr/pgmspace.h#L106 (identical fix in a different repo by somebody else)