### PR TITLE
Fixed GPIOTE interrupt priority

### DIFF
--- a/cores/nRF5/WInterrupts.c
+++ b/cores/nRF5/WInterrupts.c
@@ -42,7 +42,7 @@ static void __initialize()
 
   NVIC_DisableIRQ(GPIOTE_IRQn);
   NVIC_ClearPendingIRQ(GPIOTE_IRQn);
-  NVIC_SetPriority(GPIOTE_IRQn, 1);
+  NVIC_SetPriority(GPIOTE_IRQn, 2);
   NVIC_EnableIRQ(GPIOTE_IRQn);
 }
 


### PR DESCRIPTION
Priority 1 is reserved by the SoftDevice and shall not be used by any application code.
BLE stack doesn't work correctly together with attachInterrupt as reported [here](https://github.com/sandeepmistry/arduino-BLEPeripheral/issues/205).
Priority 2 is the correct one for high priority interrupts [according to the docs](https://infocenter.nordicsemi.com/topic/sds_s132/SDS/s1xx/processor_avail_interrupt_latency/exception_mgmt_sd.html).