### PR TITLE
Update the urls to the Nordic Softdevice hex files

### DIFF
--- a/softdevices.txt
+++ b/softdevices.txt
@@ -1,10 +1,10 @@
 names=s110,s130,s132
 
-s110.url=http://www.nordicsemi.com/eng/content/download/80234/1351257/file/s110_nrf51_8.0.0.zip
+s110.url=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SoftDevices/S110/s110nrf51800.zip
 s110.filename=s110_nrf51_8.0.0_softdevice.hex
 
-s130.url=http://www.nordicsemi.com/eng/content/download/95150/1606929/file/s130_nrf51_2.0.1.zip
+s130.url=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SoftDevices/S130/s130nrf51201.zip
 s130.filename=s130_nrf51_2.0.1_softdevice.hex
 
-s132.url=http://www.nordicsemi.com/eng/content/download/95151/1606944/file/s132_nrf52_2.0.1.zip
+s132.url=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SoftDevices/S132/s132nrf52201.zip
 s132.filename=s132_nrf52_2.0.1_softdevice.hex


### PR DESCRIPTION
I have found the correct links for the zip files. The older links are now dead and give a 404 error.

I have checked the zip files and despite having a very specific name they still contain a generically named *.hex* file that is consistent with the previous names 

For example: `s110nrf51800.zip` contains `s110_nrf51_8.0.0_softdevice.hex`