### PR TITLE
Calliope: Add analog pins A6-A7

### DIFF
--- a/variants/CalliopeMini/variant.cpp
+++ b/variants/CalliopeMini/variant.cpp
@@ -21,13 +21,13 @@
 
 const uint32_t g_ADigitalPinMap[] = {
   // 0 - 19 (available on expension connector)
-  0, // A0 - left pad
-  1, // A1 - bottom left pad; analog input
-  2, // A2 - bottom right pad; analog input
-  22, // A3 - right pad; SPI SCLK
-  4, // LED row 1; analog input
-  5, // LED row 2; analog input
-  6, // LED row 3; analog input
+  0, // left pad (not analog)
+  1, // bottom left pad; A1
+  2, // bottom right pad; A2
+  22, // right pad; SPI SCLK (not analog)
+  4, // LED row 1; A3
+  5, // LED row 2; A4
+  6, // LED row 3; A5
   7, // LED row 4
   8, // LED row 5
   9, // LED row 6
@@ -37,23 +37,23 @@ const uint32_t g_ADigitalPinMap[] = {
   13, // LED column 1
   14, // LED column 2
   15, // LED column 3
-  26, // serial RX; SPI MISO
-  27, // serial TX; SPI MOSI
+  26, // serial RX; SPI MISO, A6
+  27, // serial TX; SPI MOSI, A7
   20, // SDA
   19, // SCL
 
   // 20-25 (internal; not available on external connector)
   17, // button A
-  3, // microphone (shown as c21 on Calliope pinout)
+  23, // unassigned
   16, // button B
   28, // motor driver enable
   29, // motor driver in1
-  30,  // motor driver in2
+  30, // motor driver in2
 
   // 26-30
   18, // neopixel
   21, // accelerometer chip interrupt
-  23, // unassigned
+  3,  // microphone; A0
   24, // usb serial TX
   25, // usb serial RX
 };

--- a/variants/CalliopeMini/variant.h
+++ b/variants/CalliopeMini/variant.h
@@ -50,12 +50,14 @@ extern "C"
 
 // Analog pins
 
-#define PIN_A0               (21) // microphone (note: pad 0 is not an analog input!)
+#define PIN_A0               (28) // microphone (note: pad 0 is not an analog input!)
 #define PIN_A1               (1) // pad 1
 #define PIN_A2               (2) // pad 2
 #define PIN_A3               (4) // connector pin 4
 #define PIN_A4               (5) // connector pin 5
 #define PIN_A5               (6) // connector pin 6
+#define PIN_A6               (16) // connector pin 16
+#define PIN_A7               (17) // connector pin 17
 
 static const uint8_t A0  = PIN_A0;
 static const uint8_t A1  = PIN_A1;
@@ -63,6 +65,8 @@ static const uint8_t A2  = PIN_A2;
 static const uint8_t A3  = PIN_A3;
 static const uint8_t A4  = PIN_A4;
 static const uint8_t A5  = PIN_A5;
+static const uint8_t A6  = PIN_A6;
+static const uint8_t A7  = PIN_A7;
 #define ADC_RESOLUTION 10
 
 // Serial interface


### PR DESCRIPTION
Make connector pins 16 and 17 available as analog inputs A6 and A7

Update pin map comments in variant.cpp

Swap microphone (P0.03) with unused pin (P0.23) in the pin map to make it easier to prevent digital pin access to the microphone pin.
(The microphone pin should never be used as a digital output since that could damage the microphone amplifier).
P0.03 is now g_ADigitalPinMap[28]. Since PIN_A0 now points to that entry, and the microphone is only accessed by reading analog pin A0.
This change should be transparent to any existing code.