### PR TITLE
Fix Arduino.h `portOutputRegister()` and `portModeRegister()`

### DIFF
--- a/cores/nRF5/Arduino.h
+++ b/cores/nRF5/Arduino.h
@@ -109,9 +109,9 @@ void loop( void ) ;
 #error "Unsupported GPIO_COUNT"
 #endif
 
-#define portOutputRegister(port)   ( &(port->OUTSET) )
+#define portOutputRegister(port)   ( &(port->OUT) )
 #define portInputRegister(port)    ( &(port->IN) )
-#define portModeRegister(port)     ( &(port->DIRSET) )
+#define portModeRegister(port)     ( &(port->DIR) )
 #define digitalPinHasPWM(P)        ( true )
 
 /*


### PR DESCRIPTION
These functions were using the `OUTSET` and `DIRSET` registers instead of `OUT` and `DIR`. The `SET` version of these registers only do something when a "1" is written to any of their bits, writting a "0" does nothing.

From the nRF52833 datasheet:
<img width="714" alt="image" src="https://user-images.githubusercontent.com/4189262/173206945-e7d10802-f1ba-4422-ad88-8999494a64ef.png">
<img width="715" alt="image" src="https://user-images.githubusercontent.com/4189262/173206952-f1ab781a-1db8-4e88-b3c7-4271d747c0c4.png">

Found this issue when using some of the Adafruit libraries using a `BUSIO_USE_FAST_PINIO` macro that enables utilisation of these functions, and noticed that some of the pins were not being driven low, only high.
Using this patch locally fixed the issue.