### PR TITLE
corrects A3 from pin 3 to pin 18(C18), adds A7 as pin 16(C16)

### DIFF
--- a/variants/CalliopeminiV3/variant.cpp
+++ b/variants/CalliopeminiV3/variant.cpp
@@ -27,7 +27,7 @@ const uint32_t g_ADigitalPinMap[] = {
   17, // SCK
   1,  // MISO
   13, // MOSI
-  29, // A5, C16_A1RX (Calliope change)
+  29, // A7, C16_A1RX (Calliope change)
 
   // 17 + 18
   34, // P1.02 C17 (Calliope exclusive pin)

--- a/variants/CalliopeminiV3/variant.h
+++ b/variants/CalliopeminiV3/variant.h
@@ -34,10 +34,11 @@ extern "C"
 #define PIN_A0				(0)
 #define PIN_A1				(1)
 #define PIN_A2				(2)
-#define PIN_A3				(3)
+#define PIN_A3				(18)
 #define PIN_A4				(4)
 #define PIN_A5				(10)
 #define PIN_A6				(29)
+#define PIN_A7				(16)
 
 #define ADC_RESOLUTION 10
 static const uint8_t A0 = PIN_A0;
@@ -47,6 +48,7 @@ static const uint8_t A3 = PIN_A3;
 static const uint8_t A4 = PIN_A4;
 static const uint8_t A5 = PIN_A5;
 static const uint8_t A6 = PIN_A6;
+static const uint8_t A7 = PIN_A7;
 
 // Serial
 


### PR DESCRIPTION
Dear Sandeep, 
we found out, that the analog pin A3 was wrongly connected to pin 3, and corrected that. Also the pin 16 was not available within the analog pin notation, so we added this as well. in _variant.cpp_ only one comment was corrected. I think this change is minor and does not necessarily need a new releaase, since all the pins were already accessible using pin numbers. Still good, to have it in the future. 
Kind regards,
Hugo