### PR TITLE
analog: nrf52: Add acquisition time configuration function

### DIFF
--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -49,6 +49,42 @@ typedef enum _eAnalogReference
 } eAnalogReference ;
 #endif
 
+#if defined(NRF52_SERIES)
+/*
+ * \brief Acquisition time enumeration. To be used with \ref analogAcquisitionTime
+ */
+typedef enum _eAcquisitionTime
+{
+  AT_DEFAULT,
+  AT_3us,
+  AT_5us,
+  AT_10us,
+  AT_15us,
+  AT_20us,
+  AT_40us
+} eAcquisitionTime ;
+
+/*
+ * \brief Set the acquisition time of the ADC.
+ * Default value: 3us.
+ * Acquision time should match the maximum source resistance of the signal.
+ * See the '37.9 Acquisition time' chapter of the datasheet for more details.
+ *
+ * <table>
+ * <caption>Acquisition Time</caption>
+ * <tr><th>Acquisition Time<th>Maximum source resistance
+ * <tr><td>3us  <td>10kOhm
+ * <tr><td>5us  <td>40kOhm
+ * <tr><td>10us <td>100kOhm
+ * <tr><td>15us <td>200kOhm
+ * <tr><td>20us <td>400kOhm
+ * <tr><td>40us <td>800kOhm
+ * </table>
+ *
+ * \param ulMmode
+ */
+extern void analogAcquisitionTime( eAcquisitionTime ulMode );
+#endif
 
 /*
  * \brief Configures the reference voltage used for analog input (i.e. the value used as the top of the input range).

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -28,6 +28,7 @@ extern "C" {
 
 static uint32_t saadcReference = SAADC_CH_CONFIG_REFSEL_Internal;
 static uint32_t saadcGain      = SAADC_CH_CONFIG_GAIN_Gain1_5;
+static uint32_t saadcAcqTime   = SAADC_CH_CONFIG_TACQ_3us;
 
 static NRF_PWM_Type* pwms[PWM_COUNT] = {
   NRF_PWM0,
@@ -97,6 +98,37 @@ void analogReference( eAnalogReference ulMode )
     case AR_VDD4:
       saadcReference = SAADC_CH_CONFIG_REFSEL_VDD1_4;
       saadcGain      = SAADC_CH_CONFIG_GAIN_Gain1_4;
+      break;
+  }
+}
+
+void analogAcquisitionTime( eAcquisitionTime ulMode )
+{
+  switch ( ulMode ) {
+    case AT_DEFAULT:
+    case AT_3us:
+      saadcAcqTime = SAADC_CH_CONFIG_TACQ_3us;
+      break;
+
+    case AT_5us:
+      saadcAcqTime = SAADC_CH_CONFIG_TACQ_5us;
+      break;
+
+    case AT_10us:
+      saadcAcqTime = SAADC_CH_CONFIG_TACQ_10us;
+      break;
+
+    case AT_15us:
+      saadcAcqTime = SAADC_CH_CONFIG_TACQ_15us;
+      break;
+
+    case AT_20us:
+      saadcAcqTime = SAADC_CH_CONFIG_TACQ_20us;
+      break;
+
+    case AT_40us:
+    default:
+      saadcAcqTime = SAADC_CH_CONFIG_TACQ_40us;
       break;
   }
 }
@@ -176,7 +208,7 @@ uint32_t analogRead( uint32_t ulPin )
                             | ((SAADC_CH_CONFIG_RESP_Bypass   << SAADC_CH_CONFIG_RESN_Pos)   & SAADC_CH_CONFIG_RESN_Msk)
                             | ((saadcGain                     << SAADC_CH_CONFIG_GAIN_Pos)   & SAADC_CH_CONFIG_GAIN_Msk)
                             | ((saadcReference                << SAADC_CH_CONFIG_REFSEL_Pos) & SAADC_CH_CONFIG_REFSEL_Msk)
-                            | ((SAADC_CH_CONFIG_TACQ_3us      << SAADC_CH_CONFIG_TACQ_Pos)   & SAADC_CH_CONFIG_TACQ_Msk)
+                            | ((saadcAcqTime                  << SAADC_CH_CONFIG_TACQ_Pos)   & SAADC_CH_CONFIG_TACQ_Msk)
                             | ((SAADC_CH_CONFIG_MODE_SE       << SAADC_CH_CONFIG_MODE_Pos)   & SAADC_CH_CONFIG_MODE_Msk);
   NRF_SAADC->CH[0].PSELN = pin;
   NRF_SAADC->CH[0].PSELP = pin;


### PR DESCRIPTION
The new function allows using `analogRead()` to read signals with high source resistance by adjusting acquisition time of the SAADC.

The feature is only available in nRF52 devices.