### PR TITLE
Avoid custom MCU definition being redefined as NRF52832

### DIFF
--- a/cores/nRF5/SDK/components/device/nrf.h
+++ b/cores/nRF5/SDK/components/device/nrf.h
@@ -90,9 +90,19 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 /* Redefine "old" too-generic name NRF52 to NRF52832_XXAA to keep backwards compatibility. */
-#if defined (NRF52)
-    #ifndef NRF52832_XXAA
-        #define NRF52832_XXAA
+/* only do this if a specific MCU part is not defined to avoid redefining as NRF52832_XXAA */
+#if !defined(NRF52805_XXAA) &&\
+    !defined(NRF52810_XXAA) &&\
+    !defined(NRF52811_XXAA) &&\
+    !defined(NRF52820_XXAA) &&\
+    !defined(NRF52832_XXAA) &&\
+    !defined(NRF52832_XXAB) &&\
+    !defined(NRF52833_XXAA) &&\
+    !defined(NRF52840_XXAA)
+    #if defined (NRF52)
+        #ifndef NRF52832_XXAA
+            #define NRF52832_XXAA
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
the CPP Define NRF52 becomes defined in the `nrf5.py` file  (by `"%s" % board.get("build.mcu", "")[0:5].upper(),`)
This definition sets the MCU to NRF52832 for backwards compatibility. 

The NRF52840 has 2 GPIO ports (P0 with 32 GPIOs and P1 with 16 GPIOs)

Using an NRF52840 MCU on a custom board or the NRF52_dk (PCA10056) board results in only being able to access P0 due to the MCU being defined as NRF52832, resulting in GPIO_COUNT == 1

This does not allow the P1 pins to be accessed (P1.00 > P1.15)
These pins are used for the Arduino style header on the PCA10056 board. 

This fix checks for an existing MCU definition and will not redefine this as NRF52832 (which only has as single GPIO port)
