### PR TITLE
Creates the NRF52840DK variant

### DIFF
--- a/variants/nRF52840DK/pins_arduino.h
+++ b/variants/nRF52840DK/pins_arduino.h
@@ -1,0 +1,17 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// API compatibility
+#include "variant.h"

--- a/variants/nRF52840DK/variant.cpp
+++ b/variants/nRF52840DK/variant.cpp
@@ -1,0 +1,75 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2024 Joe Campbell All right reserved. 
+  
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "variant.h"
+
+const uint32_t g_ADigitalPinMap[] = {
+  // D0 - D7
+  33, // P1.01
+  34, // P1.02 
+  35, // P1.03
+  36, // P1.04
+  37, // P1.05
+  38, // P1.06
+  39, // P1.07
+  40, // P1.08
+
+  // D8 - D13
+  42, // P1.10
+  43, // P1.11
+  44, // P1.12
+  45, // P1.13
+  46, // P1.14
+  47, // P1.15
+  
+  // A0 - A7
+  3,  // P0.03
+  4,  // P0.04
+  28, // P0.28
+  29, // P0.29
+  30, // P0.30
+  31, // P0.31
+  5,  // P0.05
+  2,  // P0.02
+
+  // SDA, SCL
+  26, // P0.26
+  27, // P0.27
+
+  // RX, TX
+  8, // P0.08
+  6, // P0.06  
+
+  // LED Pins
+  13, // P0.13
+  14, // P0.14
+  15, // P0.15
+  16, // P0.16
+
+  // Button Pins
+  11, // P0.11
+  12, // P0.12
+  24, // P0.24
+  25, // P0.25
+
+  // NFC Pins
+  9,  // P0.09
+  10, // P0.10
+};

--- a/variants/nRF52840DK/variant.h
+++ b/variants/nRF52840DK/variant.h
@@ -1,0 +1,125 @@
+/*
+  Copyright (c) 2014-2015 Arduino LLC.  All right reserved.
+  Copyright (c) 2016 Sandeep Mistry All right reserved.
+  Copyright (c) 2024 Joe Campbell All right reserved.
+  
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _VARIANT_NRF52_DK_
+#define _VARIANT_NRF52_DK_
+
+/** Master clock frequency */
+#define VARIANT_MCK       (64000000ul)
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT           (36u)
+#define NUM_DIGITAL_PINS     (28u)
+#define NUM_ANALOG_INPUTS    (8u)
+#define NUM_ANALOG_OUTPUTS   (0u)
+
+// LEDs
+#define PIN_LED1                (26)
+#define PIN_LED2                (27)
+#define PIN_LED3                (28)
+#define PIN_LED4                (29)
+#define LED_BUILTIN             PIN_LED1
+
+// Buttons
+#define PIN_BUTTON1             (30)
+#define PIN_BUTTON2             (31)
+#define PIN_BUTTON3             (32)
+#define PIN_BUTTON4             (33)
+
+#define PIN_NFC_1	            (34)
+#define PIN_NFC_2	            (35)
+
+/*
+ * Analog pins
+ */
+#define PIN_A0               (14)
+#define PIN_A1               (15)
+#define PIN_A2               (16)
+#define PIN_A3               (17)
+#define PIN_A4               (18)
+#define PIN_A5               (19)
+#define PIN_A6               (20) /* AIN3 (P0.05)        */
+#define PIN_A7               (21) /* AIN0 (P0.02) / AREF */
+
+static const uint8_t A0  = PIN_A0 ; // AIN1
+static const uint8_t A1  = PIN_A1 ; // AIN2
+static const uint8_t A2  = PIN_A2 ; // AIN4
+static const uint8_t A3  = PIN_A3 ; // AIN5
+static const uint8_t A4  = PIN_A4 ; // AIN6
+static const uint8_t A5  = PIN_A5 ; // AIN7
+static const uint8_t A6  = PIN_A6 ; // AIN3 (P0.05)
+static const uint8_t A7  = PIN_A7 ; // AIN0 (P0.02) / AREF
+#define ADC_RESOLUTION    14
+
+// Other pins
+#define PIN_AREF           (21)
+static const uint8_t AREF = PIN_AREF;
+
+/*
+ * Serial interfaces
+ */
+// Serial
+#define PIN_SERIAL_RX       (24)
+#define PIN_SERIAL_TX       (25)
+
+/*
+ * SPI Interfaces
+ */
+#define SPI_INTERFACES_COUNT 1
+
+#define PIN_SPI_MISO         (12)
+#define PIN_SPI_MOSI         (11)
+#define PIN_SPI_SCK          (13)
+
+static const uint8_t SS   = 10 ;
+static const uint8_t MOSI = PIN_SPI_MOSI ;
+static const uint8_t MISO = PIN_SPI_MISO ;
+static const uint8_t SCK  = PIN_SPI_SCK ;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA         (22u)
+#define PIN_WIRE_SCL         (23u)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
previous target for the NRF52840_dk used the NRF52DK variant
The NRF52DK variant pinout is specific to the NRF52832

This is the correct pinout for the NRF52840DK with arduino style mapping