### PR TITLE
Add flush() to Print for backwards compatibility

### DIFF
--- a/cores/nRF5/Print.h
+++ b/cores/nRF5/Print.h
@@ -78,6 +78,8 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+    
+    virtual void flush() { /* Empty for backward compatibility */ }
 };
 
 #endif


### PR DESCRIPTION
Adds a `virtual void flush()` declaration to Print.

The `void flush()` function is referenced in at least one library that I know of - [SD Fat](https://github.com/adafruit/SdFat/tree/master), and if this core is used with the library, compilation fails since it tries to override `flush()`. 
This change has already been made to the Adafruit Arduino core: [Commit 33d98c0](https://github.com/adafruit/Adafruit_nRF52_Arduino/commit/33d98c01d83247da517458936648cfe419ea2d07)

And a need for this fix mentioned in several other places:
- [Adafruit nRF52 Arduino: Update to 1.7.0 to resolve SdFat/SPIFlash breakage](https://github.com/platformio/platform-nordicnrf52/issues/209)
- [library.properties: Restrict SdFat to pre-2.3 versions.](https://github.com/adafruit/Adafruit_SPIFlash/pull/190)
- [[Having trouble compiling simple sketch with Adafruit CLUE](https://community.platformio.org/t/having-trouble-compiling-simple-sketch-with-adafruit-clue/47550/2)

Thank you.